### PR TITLE
Set up initial project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints/
+
+# Data and model artifacts
+/data/
+!/data/README.md
+/models/
+!/models/README.md
+
+# IDEs and editors
+.vscode/
+.idea/
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # FutureLatents
+
 World Model to predict future latents.
+
+## Project Structure
+
+- `data/` - datasets and related assets (not tracked in git)
+- `models/` - trained model checkpoints (not tracked)
+- `notebooks/` - exploratory notebooks
+- `src/` - core library code
+- `training/` - training scripts
+
+See `requirements.txt` for dependencies.

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+# Data\nThis directory stores dataset files. Raw data should not be committed to git.

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,1 @@
+# Models\nPre-trained models and checkpoints are stored here. Do not commit large binaries.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+# Add project dependencies here
+numpy
+pandas
+torch

--- a/src/futurelatents/__init__.py
+++ b/src/futurelatents/__init__.py
@@ -1,0 +1,2 @@
+"""FutureLatents core library.\n"""
+__all__ = []

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,0 +1,1 @@
+"""Training package.\n"""

--- a/training/train.py
+++ b/training/train.py
@@ -1,0 +1,9 @@
+"""Entry point for model training."""
+
+def main():
+    """Run the training pipeline."""
+    pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- scaffold directories for data, models, notebooks, source code, and training
- add placeholders and initial training entry point
- define common ignores and dependencies
- describe project structure in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68825d13ee248332bfb96d85c92478e2