### PR TITLE
Add Kinetics-400 dataset configuration and CLI arg handling

### DIFF
--- a/default.yaml
+++ b/default.yaml
@@ -1,0 +1,4 @@
+datasets:
+  kinetics_400:
+    paths:
+      csv: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_train_paths.csv

--- a/src/futurelatents/__init__.py
+++ b/src/futurelatents/__init__.py
@@ -1,2 +1,5 @@
-"""FutureLatents core library.\n"""
-__all__ = []
+"""FutureLatents core library."""
+
+from .kinetics_400 import Kinetics400
+
+__all__ = ["Kinetics400"]

--- a/src/futurelatents/kinetics_400.py
+++ b/src/futurelatents/kinetics_400.py
@@ -1,0 +1,9 @@
+"""Minimal dataset representation for Kinetics-400."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Kinetics400:
+    """Dataset placeholder for Kinetics-400."""
+    csv_path: str

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,9 @@ from utils.parser import create_parser
 def main() -> None:
     """Entry point for the FutureLatents application."""
     parser = create_parser()
-    parser.parse_args()
+    args = parser.parse_args()
+    # Placeholder for using args in future development
+    _ = args
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add default configuration file including Kinetics-400 CSV path
- introduce minimal Kinetics-400 dataset definition and expose from package
- capture parsed CLI arguments in main script for future use

## Testing
- `python -m pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af134680bc83329d307e20c1e8b82e