### PR TITLE
Implement Kinetics400 dataset and load from config

### DIFF
--- a/datasets/kinetics_400.py
+++ b/datasets/kinetics_400.py
@@ -1,9 +1,46 @@
-"""Minimal dataset representation for Kinetics-400."""
+"""PyTorch dataset for the Kinetics-400 annotations."""
 
-from dataclasses import dataclass
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+from torch.utils.data import Dataset
 
 
-@dataclass
-class Kinetics400:
-    """Dataset placeholder for Kinetics-400."""
-    csv_path: str
+class Kinetics400(Dataset):
+    """Dataset representing the Kinetics-400 annotation CSV.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the CSV file containing the dataset annotations.
+    """
+
+    def __init__(self, csv_path: str | Path) -> None:
+        self.csv_path = str(csv_path)
+        self.dataframe = pd.read_csv(self.csv_path)
+
+    def __len__(self) -> int:  # pragma: no cover - simple wrapper
+        """Return the number of samples in the dataset."""
+
+        return len(self.dataframe)
+
+    def __getitem__(self, index: int) -> Dict[str, Any]:
+        """Retrieve a sample from the dataset.
+
+        Parameters
+        ----------
+        index:
+            Index of the sample to retrieve.
+
+        Returns
+        -------
+        Dict[str, Any]
+            A dictionary representing the selected row from the CSV file.
+        """
+
+        row = self.dataframe.iloc[index]
+        return row.to_dict()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 numpy
 pandas
 torch
+pyyaml

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+
+import yaml
+
+from datasets.kinetics_400 import Kinetics400
 from utils.parser import create_parser
 
 
@@ -5,7 +10,14 @@ def main() -> None:
     """Entry point for the FutureLatents application."""
     parser = create_parser()
     args = parser.parse_args()
-    breakpoint()
+
+    with open(Path(args.config_path)) as f:
+        config = yaml.safe_load(f)
+
+    csv_path = config["datasets"]["kinetics_400"]["paths"]["csv"]
+    dataset = Kinetics400(csv_path)
+
+    _ = len(dataset)  # simple usage to avoid unused variable warnings
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace placeholder with a functional `Kinetics400` PyTorch dataset that reads annotations from a CSV via pandas
- load configuration and instantiate the dataset in `main.py`
- declare `pyyaml` as a dependency

## Testing
- `python -m src.main --config_path configs/default.yaml` (fails: No module named 'yaml')
- `python - <<'PY'\nimport pandas as pd\nfrom datasets.kinetics_400 import Kinetics400\nimport tempfile, os\n\ndf = pd.DataFrame({'path': ['a.mp4', 'b.mp4'], 'label': [0,1]})\nwith tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False) as f:\n    df.to_csv(f.name, index=False)\n    tmp_path = f.name\n\nprint('tmp csv', tmp_path)\n\ndataset = Kinetics400(tmp_path)\nprint('len', len(dataset))\nprint('item0', dataset[0])\n\nos.unlink(tmp_path)\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68af161e01448332810c54de8050d10b