### PR TITLE
feat: make kinetics dataset configurable

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,4 +1,6 @@
 datasets:
   kinetics_400:
+    n_frame: 64
+    stride: 2
     paths:
       csv: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_train_paths.csv


### PR DESCRIPTION
## Summary
- expose number of frames and stride parameters for Kinetics-400 dataset
- generalize frame loading helper to handle arbitrary frame counts and strides

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af1b604f8483329737d6b6c829ed81