### PR TITLE
Add latent video model skeleton and wire into main

### DIFF
--- a/src/futurelatents/models/__init__.py
+++ b/src/futurelatents/models/__init__.py
@@ -1,0 +1,5 @@
+"""Model definitions for FutureLatents."""
+
+from .latent_video_model import LatentVideoModel
+
+__all__ = ["LatentVideoModel"]

--- a/src/futurelatents/models/latent_video_model.py
+++ b/src/futurelatents/models/latent_video_model.py
@@ -1,0 +1,28 @@
+"""Latent video generative model."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import torch.nn as nn
+from transformers import AutoModel
+
+
+class LatentVideoModel(nn.Module):
+    """Video generative model that operates in latent space.
+
+    Parameters
+    ----------
+    config: dict
+        Configuration dictionary that must include ``"backbone"`` with a
+        ``"hf_repo"`` entry specifying the pretrained model to use as
+        encoder.
+    """
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        super().__init__()
+        self.config = config
+        # Backbone encoder producing latent representations
+        self.encoder = AutoModel.from_pretrained(config["backbone"]["hf_repo"])
+        # Placeholder for future diffusion transformer component
+        self.diffusion_transformer = None

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
 import yaml
-from transformers import AutoModel, AutoVideoProcessor
+from transformers import AutoVideoProcessor
+
+from futurelatents.models import LatentVideoModel
 
 from datasets.kinetics_400 import Kinetics400
 from utils.parser import create_parser
@@ -31,7 +33,7 @@ def main() -> None:
     config = load_config(Path(args.config_path))
     dataset = Kinetics400(config)
 
-    model = AutoModel.from_pretrained(config["backbone"]["hf_repo"]).eval()
+    model = LatentVideoModel(config).eval()
     processor = AutoVideoProcessor.from_pretrained(config["backbone"]["hf_repo"])
     
     # try to get sample


### PR DESCRIPTION
## Summary
- introduce `LatentVideoModel` skeleton that holds an encoder loaded from pretrained weights
- expose model via `futurelatents.models`
- instantiate the new model in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af2c16f5508332925ee30173ff6894