### PR TITLE
Couple original preprocessor with model and streamline training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 World Model to predict future latents.
 
+This repository now provides a simple training pipeline that freezes the
+pretrained encoder weights by default and keeps the original Hugging Face
+``AutoVideoProcessor`` alongside the model so preprocessing and encoding stay
+coupled. Optimisers can be constructed by passing ``model.trainable_modules()``
+which returns only the parameters that require gradients.
+
 ## Project Structure
 
 - `data/` - datasets and related assets (not tracked in git)

--- a/training/main.py
+++ b/training/main.py
@@ -1,0 +1,30 @@
+"""Entry point for model training."""
+
+from __future__ import annotations
+
+import torch
+
+from futurelatents.models import LatentVideoModel
+
+
+def main() -> None:  # pragma: no cover - simple example script
+    """Run a minimal training pipeline.
+
+    This script demonstrates how to construct an optimiser that only updates
+    parameters marked as trainable within :class:`LatentVideoModel`. The model
+    freezes its encoder weights by default, so the returned parameter iterator
+    will be empty unless other modules with trainable parameters are added.
+    """
+
+    # Example configuration for the VJEPA 2 backbone; replace the repository
+    # name with a local checkpoint as needed.
+    config = {"backbone": {"hf_repo": "facebook/vjepa2-vitl-fpc64-256"}}
+    model = LatentVideoModel(config)
+
+    # Define the optimiser over trainable parameters only
+    optimizer = torch.optim.AdamW(model.trainable_modules(), lr=1e-4)
+    print(optimizer)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/train.py
+++ b/training/train.py
@@ -1,9 +1,0 @@
-"""Entry point for model training."""
-
-def main():
-    """Run the training pipeline."""
-    pass
-
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
## Summary
- drop custom `VideoPreprocessor` and load `AutoVideoProcessor` inside `LatentVideoModel`
- remove BERT example and move training entrypoint to `training/main.py`
- update exports and docs to reflect simplified preprocessing and training

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af30658b208332aa5d761bb9121128