### PR TITLE
Fix package import for main module

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,10 @@ from pathlib import Path
 import yaml
 from transformers import AutoVideoProcessor
 
-from futurelatents.models import LatentVideoModel
+# Import the project package relative to this module so that running
+# ``python -m src.main`` works without requiring ``src`` on the
+# ``PYTHONPATH``.
+from .futurelatents.models import LatentVideoModel
 
 from datasets.kinetics_400 import Kinetics400
 from utils.parser import create_parser


### PR DESCRIPTION
## Summary
- ensure `src.main` loads project modules via relative import

## Testing
- `python -m py_compile src/main.py`
- `pytest`
- `python -m src.main` *(fails: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68af354131948332b6814723bc24b3de