### PR TITLE
Add optimizer/scheduler config and parameter count logging

### DIFF
--- a/configs/vjepa2_kinetics_400.yaml
+++ b/configs/vjepa2_kinetics_400.yaml
@@ -1,3 +1,15 @@
 defaults:
   - backbones: vjepa2
   - datasets: kinetics_400
+
+optimizer:
+  name: AdamW
+  params:
+    lr: 1e-4
+    weight_decay: 0.0
+
+scheduler:
+  name: ConstantLR
+  params:
+    factor: 1.0
+    total_iters: 0

--- a/src/futurelatents/models/latent_video_model.py
+++ b/src/futurelatents/models/latent_video_model.py
@@ -31,6 +31,8 @@ class LatentVideoModel(nn.Module):
         self.diffusion_transformer = None
         # Freeze encoder weights by default
         self.set_encoder_trainable(False)
+        # Report total parameter count for informational purposes
+        self.print_num_parameters()
 
     # ------------------------------------------------------------------
     # Training helpers
@@ -47,6 +49,17 @@ class LatentVideoModel(nn.Module):
     # Backwards compatibility with the example API
     def trainable_modules(self) -> Iterable[nn.Parameter]:  # pragma: no cover - simple wrapper
         return self.trainable_parameters()
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def num_parameters(self) -> int:
+        """Return the total number of parameters in the model."""
+        return sum(p.numel() for p in self.parameters())
+
+    def print_num_parameters(self) -> None:  # pragma: no cover - simple print helper
+        """Print the total number of parameters in the model."""
+        print(f"Total parameters: {self.num_parameters():,}")
 
     # ------------------------------------------------------------------
     # Forward helpers


### PR DESCRIPTION
## Summary
- extend configuration with optimizer and scheduler parameters
- filter frozen params from optimizer construction
- add helper to report total model parameters on init

## Testing
- `pytest -q`
- `python -m py_compile src/futurelatents/models/latent_video_model.py src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af35fba1d4833289234a259314e2f2