### PR TITLE
fix: adjust futurelatents init

### DIFF
--- a/src/futurelatents/__init__.py
+++ b/src/futurelatents/__init__.py
@@ -1,5 +1,5 @@
 """FutureLatents core library."""
 
-from .kinetics_400 import Kinetics400
+from .models import LatentVideoModel
 
-__all__ = ["Kinetics400"]
+__all__ = ["LatentVideoModel"]


### PR DESCRIPTION
## Summary
- correct import in `futurelatents` package to use available `models` submodule

## Testing
- `python -m src.main --config_path configs/vjepa2_kinetics_400.yaml` *(fails: No module named 'transformers')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement transformers)*

------
https://chatgpt.com/codex/tasks/task_e_68af5e9a52e483329646cc7a35a6b7cc