### PR TITLE
Refactor configuration and add model parameter counting

### DIFF
--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -1,0 +1,3 @@
+trainer:
+  learning_rate: 1e-5
+  weight_decay: 0.01

--- a/configs/vjepa2_kinetics_400.yaml
+++ b/configs/vjepa2_kinetics_400.yaml
@@ -1,6 +1,5 @@
-defaults:
-  - backbones: vjepa2
-  - datasets: kinetics_400
+inherits:
+  - datasets/kinetics_400.yaml
+  - backbones/vjepa2.yaml
+  - training/trainer.yaml
 encoder_trainable: false
-learning_rate: 1e-5
-weight_decay: 0.01

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pandas
 torch
 pyyaml
 transformers
+omegaconf

--- a/src/futurelatents/models/latent_video_model.py
+++ b/src/futurelatents/models/latent_video_model.py
@@ -56,3 +56,24 @@ class LatentVideoModel(nn.Module):
         """Preprocess and encode a batch of video frames."""
         inputs = self.preprocessor(video, return_tensors="pt")
         return self.encoder(inputs["pixel_values"])
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+    def count_parameters(self) -> Dict[str, int]:  # pragma: no cover - simple reporting
+        """Return parameter counts for sub-modules and the total.
+
+        Each module's parameter count is printed as ``"<name>: <count>"`` and a
+        dictionary with the counts is returned.
+        """
+        counts: Dict[str, int] = {}
+        counts["encoder"] = sum(p.numel() for p in self.encoder.parameters())
+        if self.diffusion_transformer is not None:
+            counts["diffusion_transformer"] = sum(
+                p.numel() for p in self.diffusion_transformer.parameters()
+            )
+        total = sum(counts.values())
+        counts["total"] = total
+        for name, num in counts.items():
+            print(f"{name}: {num}")
+        return counts

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 
-import yaml
-from transformers import AutoVideoProcessor
-
 # Import the project package relative to this module so that running
 # ``python -m src.main`` works without requiring ``src`` on the
 # ``PYTHONPATH``.
@@ -10,23 +7,8 @@ from .futurelatents.models import LatentVideoModel
 breakpoint()
 from datasets.kinetics_400 import Kinetics400
 from utils.parser import create_parser
+from utils.config import load_config
 import torch
-
-
-def load_config(path: Path) -> dict:
-    """Load configuration with simple inheritance support."""
-    with open(path) as f:
-        config = yaml.safe_load(f)
-    defaults = config.pop("defaults", [])
-    merged = {}
-    for item in defaults:
-        for key, value in item.items():
-            sub_path = path.parent / key / f"{value}.yaml"
-            with open(sub_path) as sf:
-                sub_cfg = yaml.safe_load(sf)
-            merged.update(sub_cfg)
-    merged.update(config)
-    return merged
 
 
 def main() -> None:
@@ -38,8 +20,8 @@ def main() -> None:
     dataset = Kinetics400(config)
 
     model = LatentVideoModel(config)
-    learning_rate = float(config["learning_rate"])
-    weight_decay = float(config.get("weight_decay", 0.01))
+    learning_rate = float(config["trainer"]["learning_rate"])
+    weight_decay = float(config["trainer"].get("weight_decay", 0.01))
     optimizer = torch.optim.AdamW(
         model.parameters(), lr=learning_rate, weight_decay=weight_decay
     )

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+from typing import Any, Dict
+
+from omegaconf import OmegaConf
+
+
+def _merge_with_conflict(base: OmegaConf, override: OmegaConf) -> OmegaConf:
+    """Merge two ``OmegaConf`` objects reporting conflicting keys."""
+    for key in override.keys():
+        if key in base and base[key] != override[key]:
+            print(f"Overriding key '{key}': {base[key]} -> {override[key]}")
+    return OmegaConf.merge(base, override)
+
+
+def load_config(path: Path) -> Dict[str, Any]:
+    """Load YAML configuration with support for simple file inheritance.
+
+    The YAML file may contain an ``inherits`` list of relative file paths. These
+    referenced configs are loaded first and merged sequentially. Later values
+    override earlier ones with a notice printed for any conflicting keys.
+    """
+    cfg = OmegaConf.load(path)
+    inherits = cfg.pop("inherits", [])
+    merged = OmegaConf.create()
+    for rel in inherits:
+        sub_path = (path.parent / rel).resolve()
+        sub_cfg = OmegaConf.create(load_config(sub_path))
+        merged = _merge_with_conflict(merged, sub_cfg)
+    merged = _merge_with_conflict(merged, cfg)
+    return OmegaConf.to_container(merged, resolve=True)


### PR DESCRIPTION
## Summary
- allow configs to inherit from dataset, backbone, and trainer YAMLs via explicit `inherits` list
- centralize training hyperparameters in `configs/training/trainer.yaml`
- load configs with OmegaConf and conflict reporting
- add `LatentVideoModel.count_parameters` helper

## Testing
- `pip install omegaconf` *(fails: Cannot connect to proxy)*
- `pytest`
- `python -m py_compile src/main.py utils/config.py src/futurelatents/models/latent_video_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68af6781009483328f661c864eff5e9b