### PR TITLE
Add utility to display resolved configuration

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from .futurelatents.models import LatentVideoModel
 from datasets.kinetics_400 import Kinetics400
 from utils.parser import create_parser
-from utils.config import load_config
+from utils.config import load_config, print_config
 import torch
 
 
@@ -16,6 +16,7 @@ def main() -> None:
     args = parser.parse_args()
 
     config = load_config(Path(args.config_path))
+    print_config(config)
     dataset = Kinetics400(config)
 
     model = LatentVideoModel(config)

--- a/utils/config.py
+++ b/utils/config.py
@@ -28,3 +28,16 @@ def load_config(path: Path) -> Dict[str, Any]:
         merged = _merge_with_conflict(merged, sub_cfg)
     merged = _merge_with_conflict(merged, cfg)
     return OmegaConf.to_container(merged, resolve=True)
+
+
+def print_config(config: Dict[str, Any]) -> None:
+    """Print a resolved configuration in YAML format.
+
+    Parameters
+    ----------
+    config : Dict[str, Any]
+        Configuration dictionary as returned by :func:`load_config`.
+    """
+
+    conf = OmegaConf.create(config)
+    print(OmegaConf.to_yaml(conf))


### PR DESCRIPTION
## Summary
- add `print_config` helper to show merged config as YAML
- display resolved configuration when running main entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af6b0ad4d083328649b4fe7e8b71c0