### PR TITLE
Add simple Trainer and integrate into project entrypoint

### DIFF
--- a/src/futurelatents/main.py
+++ b/src/futurelatents/main.py
@@ -1,0 +1,57 @@
+"""Entry point that wires together the model, data and trainer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+
+from .models import LatentVideoModel
+from datasets.kinetics_400 import Kinetics400
+from training.trainer import Trainer
+from utils.config import load_config, print_config
+from utils.parser import create_parser
+
+
+def main() -> None:  # pragma: no cover - thin wrapper around training loop
+    parser = create_parser()
+    args = parser.parse_args()
+
+    config = load_config(Path(args.config_path))
+    print_config(config)
+
+    # ------------------------------------------------------------------
+    # Data
+    # ------------------------------------------------------------------
+    dataset = Kinetics400(config)
+    batch_size = int(config["trainer"].get("batch_size", 1))
+    train_loader = DataLoader(dataset, batch_size=batch_size)
+
+    # In lieu of a separate validation set we reuse the training loader.
+    val_loader = train_loader
+
+    # ------------------------------------------------------------------
+    # Model and optimiser
+    # ------------------------------------------------------------------
+    model = LatentVideoModel(config)
+
+    learning_rate = float(config["trainer"]["learning_rate"])
+    weight_decay = float(config["trainer"]["weight_decay"])
+    optimizer = torch.optim.AdamW(
+        model.trainable_parameters(), lr=learning_rate, weight_decay=weight_decay
+    )
+    scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer)
+
+    # ------------------------------------------------------------------
+    # Trainer
+    # ------------------------------------------------------------------
+    trainer = Trainer(model, optimizer, scheduler)
+    epochs = int(config["trainer"].get("epochs", 1))
+    trainer.fit(train_loader, val_loader=val_loader, epochs=epochs)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    # run with "python -m src.futurelatents.main --config_path configs/vjepa2_kinetics_400.yaml"
+    main()
+

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -1,0 +1,127 @@
+"""Utilities for training FutureLatents models.
+
+This module defines a small ``Trainer`` class that provides convenience
+wrappers around the typical PyTorch training loop.  It purposefully keeps the
+implementation lightweight so that it can serve as a starting point for more
+feature rich trainers in the future.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+
+@dataclass
+class TrainState:
+    """Simple container for tracking the state of the training process."""
+
+    epoch: int = 0
+
+
+class Trainer:
+    """Basic PyTorch training helper.
+
+    Parameters
+    ----------
+    model:
+        The ``nn.Module`` to optimise.
+    optimizer:
+        Optimiser responsible for updating the model parameters.
+    scheduler:
+        Optional learning rate scheduler stepped after each optimisation step.
+    device:
+        Device on which the model and input batches should be placed.  If
+        ``None`` the trainer will use ``"cuda"`` when available, otherwise
+        ``"cpu"``.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        scheduler: Optional[torch.optim.lr_scheduler.LRScheduler] = None,
+        device: Optional[str] = None,
+    ) -> None:
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = model.to(self.device)
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.state = TrainState()
+
+    # ------------------------------------------------------------------
+    # Training utilities
+    # ------------------------------------------------------------------
+    def train_step(self, batch: dict) -> float:
+        """Perform a single optimisation step.
+
+        The example loss used here simply averages the encoder output of the
+        provided video batch.  Real projects are expected to replace this with a
+        task specific objective.
+        """
+
+        self.model.train()
+        video = batch["video"].to(self.device)
+
+        # Forward pass through the encoder and compute a dummy loss.
+        outputs = self.model.encode_video(video)
+        loss = outputs.last_hidden_state.mean()
+
+        # Optimisation step
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+        if self.scheduler is not None:
+            self.scheduler.step()
+        return loss.item()
+
+    def train_epoch(self, dataloader: DataLoader) -> float:
+        """Iterate over ``dataloader`` once and return the mean loss."""
+
+        total_loss = 0.0
+        for batch in dataloader:
+            total_loss += self.train_step(batch)
+        return total_loss / max(len(dataloader), 1)
+
+    # ------------------------------------------------------------------
+    # Validation utilities
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def val(self, dataloader: DataLoader) -> float:
+        """Evaluate the model on ``dataloader`` and return the mean loss."""
+
+        self.model.eval()
+        total_loss = 0.0
+        for batch in dataloader:
+            video = batch["video"].to(self.device)
+            outputs = self.model.encode_video(video)
+            loss = outputs.last_hidden_state.mean()
+            total_loss += loss.item()
+        return total_loss / max(len(dataloader), 1)
+
+    # ------------------------------------------------------------------
+    # High level API
+    # ------------------------------------------------------------------
+    def fit(
+        self,
+        train_loader: DataLoader,
+        val_loader: Optional[DataLoader] = None,
+        epochs: int = 1,
+    ) -> None:
+        """Run the training loop for ``epochs`` epochs."""
+
+        for epoch in range(epochs):
+            self.state.epoch = epoch
+            train_loss = self.train_epoch(train_loader)
+            msg = f"epoch {epoch + 1}/{epochs} - train_loss: {train_loss:.4f}"
+            if val_loader is not None:
+                val_loss = self.val(val_loader)
+                msg += f", val_loss: {val_loss:.4f}"
+            print(msg)
+
+
+__all__ = ["Trainer", "TrainState"]
+


### PR DESCRIPTION
## Summary
- implement basic `Trainer` with train/val loops
- add `src/futurelatents/main.py` to wire data, model and trainer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b022818f948332b2df2dc4cd008ca2