### PR TITLE
Expose dataloader workers via trainer config and integrate Trainer in main

### DIFF
--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -1,3 +1,4 @@
 trainer:
   learning_rate: 1e-5
   weight_decay: 0.01
+  num_workers: 8

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ from pathlib import Path
 # ``PYTHONPATH``.
 from .futurelatents.models import LatentVideoModel
 from datasets.kinetics_400 import Kinetics400
+from training.trainer import Trainer
 from utils.parser import create_parser
 from utils.config import load_config, print_config
 import torch
@@ -20,17 +21,23 @@ def main() -> None:
     dataset = Kinetics400(config)
 
     model = LatentVideoModel(config)
-    
+
     model.count_parameters()
-    
+
     learning_rate = float(config["trainer"]["learning_rate"])
     weight_decay = float(config["trainer"]["weight_decay"])
     optimizer = torch.optim.AdamW(
         model.parameters(), lr=learning_rate, weight_decay=weight_decay
     )
     scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer)
-    
-    dataloader = torch.utils.data.DataLoader(dataset, shuffle=True, num_workers=num_workers)
+
+    num_workers = int(config["trainer"]["num_workers"])
+    dataloader = torch.utils.data.DataLoader(
+        dataset, shuffle=True, num_workers=num_workers
+    )
+
+    trainer = Trainer(model, optimizer, scheduler)
+    trainer.fit(dataloader)
 
 
 if __name__ == "__main__":

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from typing import Iterable, Optional
 
 import torch
-from torch.utils.data import DataLoader
 
 
 @dataclass
@@ -78,7 +77,7 @@ class Trainer:
             self.scheduler.step()
         return loss.item()
 
-    def train_epoch(self, dataloader: DataLoader) -> float:
+    def train_epoch(self, dataloader: Iterable[dict]) -> float:
         """Iterate over ``dataloader`` once and return the mean loss."""
 
         total_loss = 0.0
@@ -90,7 +89,7 @@ class Trainer:
     # Validation utilities
     # ------------------------------------------------------------------
     @torch.no_grad()
-    def val(self, dataloader: DataLoader) -> float:
+    def val(self, dataloader: Iterable[dict]) -> float:
         """Evaluate the model on ``dataloader`` and return the mean loss."""
 
         self.model.eval()
@@ -107,8 +106,8 @@ class Trainer:
     # ------------------------------------------------------------------
     def fit(
         self,
-        train_loader: DataLoader,
-        val_loader: Optional[DataLoader] = None,
+        train_loader: Iterable[dict],
+        val_loader: Optional[Iterable[dict]] = None,
         epochs: int = 1,
     ) -> None:
         """Run the training loop for ``epochs`` epochs."""


### PR DESCRIPTION
## Summary
- allow setting `num_workers` through the shared `training/trainer` configuration
- build the dataloader in `src.main` using configurable workers and run training via `Trainer`
- simplify `Trainer` by dropping `DataLoader` dependency and using generic iterables

## Testing
- `python -m py_compile training/trainer.py src/main.py`
- `pip install decord` *(fails: Could not find a version that satisfies the requirement decord)*
- `python -m src.main --config_path configs/vjepa2_kinetics_400.yaml` *(fails: ModuleNotFoundError: No module named 'decord')*


------
https://chatgpt.com/codex/tasks/task_e_68b0250042b88332a5b5fca7a195b02c