### PR TITLE
docs: document flow matching configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ It currently supports VJEPA2 backbone, and Kinetics 400 dataset. Will soon suppo
 ```
 configs/   YAML experiment configuration files
 datasets/  Dataset wrappers such as Kinetics‑400
+models/    Model components including the flow transformer
 src/       Core library code and entry point
 training/  Minimal training script
 notebooks/ Exploratory notebooks (empty placeholder)
@@ -27,17 +28,29 @@ notebooks/ Exploratory notebooks (empty placeholder)
 ## Configuration
 
 Configurations can be composed using the `inherits` key. For example
-`configs/vjepa2_kinetics_400.yaml` combines dataset, backbone and training settings:
+`configs/vjepa2_kinetics_400.yaml` combines dataset, backbone, training, evaluation
+and flow‑matching settings:
 
 ```yaml
 inherits:
   - datasets/kinetics_400.yaml
   - backbones/vjepa2.yaml
   - training/trainer.yaml
+  - training/evaluation.yaml
+  - training/flow_matching.yaml
 encoder_trainable: false
 ```
 
 Run `utils.config.load_config` to resolve the hierarchy and `utils.config.print_config` to display it.
+
+### Flow matching
+
+Flow matching follows the diffusive modelling paradigm where latent tokens are
+incrementally noised and denoised.  The `training/flow_matching.yaml` file
+provides the number of training timesteps and the configuration for the
+diffusion transformer (DiT) used to predict the noise at each step.  The
+`LatentVideoModel` reads these values from the `flow_matching` section to build
+its internal DiT module.
 
 ## Usage
 

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,27 @@
+# Models
+
+This directory contains the model components used by FutureLatents.
+
+- `latent_video_model.py` couples a pretrained video encoder with a
+  flow matching transformer operating on latent tokens.
+- `DiT.py` implements a minimal diffusion transformer (DiT) that predicts
+  the noise added at each training timestep.
+
+The architecture is configured through the `flow_matching` section in the
+configuration files.  For instance, `configs/training/flow_matching.yaml`
+provides both the number of diffusion steps and the DiT hyperparameters:
+
+```yaml
+flow_matching:
+  num_train_timesteps: 500
+  dit:
+    input_dim: 1024
+    hidden_dim: 1024
+    depth: 6
+    num_heads: 8
+    mlp_ratio: 4.0
+```
+
+`LatentVideoModel` reads these values to construct the flow transformer.  If no
+`flow_matching` configuration is supplied the transformer is omitted, allowing
+experiments that focus solely on the backbone encoder.

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,10 @@
+"""Model package for FutureLatents.
+
+This exposes the main model components so they can be imported as
+``from models import LatentVideoModel, DiT``.
+"""
+
+from .DiT import DiT
+from .latent_video_model import LatentVideoModel
+
+__all__ = ["DiT", "LatentVideoModel"]


### PR DESCRIPTION
## Summary
- document flow matching setup and DiT transformer in README
- add package docs and `__init__` for models including flow-matching config sample

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b07ce9136c8332a46f6c93d2ed77c9