### PR TITLE
Embed backbone encoding in forward method

### DIFF
--- a/models/latent_video_model.py
+++ b/models/latent_video_model.py
@@ -64,14 +64,17 @@ class LatentVideoModel(nn.Module):
     # ------------------------------------------------------------------
     # Forward helpers
     # ------------------------------------------------------------------
-    def encode_video_with_backbone(self, video):  # pragma: no cover - thin wrapper
-        """Preprocess and encode a batch of video frames."""
-        inputs = self.preprocessor(video, return_tensors="pt")["pixel_values_videos"]
-        bacbone_video_features = self.encoder.get_vision_features(inputs)  # [B, N_tokens, embed_dim] = [B, 8192, 1024]
-        return bacbone_video_features
+    def forward(self, latents=None, timesteps=None, video=None):
+        """Encode videos or run the flow transformer on latent tokens.
 
-    def forward(self, latents, timesteps):
-        """Run the flow transformer on latent tokens."""
+        When ``video`` is provided, it is preprocessed and passed through the
+        backbone encoder and the resulting features are returned. Otherwise the
+        ``latents`` and ``timesteps`` are processed by the flow transformer.
+        """
+        if video is not None:
+            inputs = self.preprocessor(video, return_tensors="pt")["pixel_values_videos"]
+            return self.encoder.get_vision_features(inputs)
+
         if self.flow_transformer is None:
             raise RuntimeError("Flow transformer is not initialised")
         return self.flow_transformer(latents, timesteps)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -73,8 +73,7 @@ class Trainer:
 
         with self.accelerator.accumulate(self.model):
             with self.accelerator.autocast():
-                model = self.accelerator.unwrap_model(self.model)
-                latents = model.encode_video_with_backbone(video)
+                latents = self.model(video=video)
                 noise = torch.randn_like(latents)
                 timesteps = torch.randint(
                     0,
@@ -130,12 +129,7 @@ class Trainer:
                 else nullcontext()
             )
             with ctx:
-                model = (
-                    self.accelerator.unwrap_model(self.model)
-                    if self.accelerator is not None
-                    else self.model
-                )
-                outputs = model.encode_video_with_backbone(video)
+                outputs = self.model(video=video)
             total_loss += outputs.mean().item()
         return total_loss / max(len(dataloader), 1)
 


### PR DESCRIPTION
## Summary
- Integrate backbone encoding into `LatentVideoModel.forward` to make video encoding accessible without unwrapping the model
- Simplify training loop to call the model directly for encoding and validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0a630f7488332ad1c147396dfaa6e