### PR TITLE
Add cached Kinetics400 dataset and config

### DIFF
--- a/configs/datasets/kinetics_400_cached.yaml
+++ b/configs/datasets/kinetics_400_cached.yaml
@@ -1,0 +1,6 @@
+datasets:
+  kinetics_400_cached:
+    repeat: 1
+    path_col: out_path
+    paths:
+      metadata: /path/to/kinetics400_cached_metadata.csv

--- a/configs/vjepa2_kinetics_400_cached.yaml
+++ b/configs/vjepa2_kinetics_400_cached.yaml
@@ -1,0 +1,7 @@
+inherits:
+  - datasets/kinetics_400_cached.yaml
+  - backbones/vjepa2.yaml
+  - training/trainer.yaml
+  - training/evaluation.yaml
+  - training/flow_matching.yaml
+encoder_trainable: false

--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,33 @@
+"""Dataset factory utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .kinetics_400 import Kinetics400
+from .kinetics_400_cached import Kinetics400Cached
+
+_DATASETS = {
+    "kinetics_400": Kinetics400,
+    "kinetics_400_cached": Kinetics400Cached,
+}
+
+
+def build_dataset(config: Dict[str, Any]):
+    """Build a dataset from a configuration dictionary.
+
+    The configuration must contain a single entry under the ``datasets`` key
+    specifying which dataset to construct. The entry name is used to select the
+    appropriate dataset class.
+    """
+
+    datasets_cfg = config.get("datasets", {})
+    if len(datasets_cfg) != 1:
+        raise ValueError("Config must contain exactly one dataset specification")
+
+    name = next(iter(datasets_cfg))
+    if name not in _DATASETS:
+        raise ValueError(f"Unsupported dataset: {name}")
+
+    dataset_cls = _DATASETS[name]
+    return dataset_cls(config)

--- a/datasets/kinetics_400_cached.py
+++ b/datasets/kinetics_400_cached.py
@@ -1,0 +1,59 @@
+"""PyTorch dataset for cached Kinetics-400 embeddings."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+
+
+class Kinetics400Cached(Dataset):
+    """Dataset representing cached Kinetics-400 embeddings.
+
+    Parameters
+    ----------
+    config:
+        Global configuration containing the dataset specification.
+    """
+
+    def __init__(self, config) -> None:
+        self.config = config
+        cfg = config["datasets"]["kinetics_400_cached"]
+        self.metadata_path = str(cfg["paths"]["metadata"])
+        self.path_col = str(cfg.get("path_col", "out_path"))
+        self.repeat = int(cfg.get("repeat", 1))
+
+        self.df_metadata = pd.read_csv(self.metadata_path)
+        self.metadata_list_dict = [
+            self.df_metadata.iloc[i].to_dict() for i in range(self.df_metadata.shape[0])
+        ]
+        if len(self.metadata_list_dict) == 0:
+            raise ValueError(f"Empty dataset found in {self.metadata_path}")
+
+    def __len__(self) -> int:  # pragma: no cover - simple wrapper
+        return len(self.metadata_list_dict) * self.repeat
+
+    def _resolve_index(self, idx: int) -> int:
+        return idx % len(self.metadata_list_dict)
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        base_idx = self._resolve_index(idx)
+        record = self.metadata_list_dict[base_idx]
+
+        if self.path_col not in record:
+            raise ValueError(f"Column {self.path_col} not found in metadata")
+
+        embedding_path = record[self.path_col]
+        if not os.path.isfile(embedding_path):
+            raise FileNotFoundError(f"Embedding file not found: {embedding_path}")
+
+        embedding = torch.load(embedding_path, weights_only=False, map_location="cpu")
+
+        return {
+            "embedding": embedding,
+            "metadata": record,
+            "index": base_idx,
+        }

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ import logging
 # ``python -m src.main`` works without requiring ``src`` on the
 # ``PYTHONPATH``.
 from models.latent_video_model import LatentVideoModel
-from datasets.kinetics_400 import Kinetics400
+from datasets import build_dataset
 from training.trainer import Trainer
 from utils.parser import create_parser
 from utils.config import load_config, print_config
@@ -22,7 +22,7 @@ def main() -> None:
 
     config = load_config(Path(args.config_path))
     print_config(config)
-    dataset = Kinetics400(config)
+    dataset = build_dataset(config)
 
     model = LatentVideoModel(config)
 


### PR DESCRIPTION
## Summary
- add dataset for cached Kinetics400 embeddings
- provide dataset factory and configure build from config
- introduce configs for cached Kinetics400

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b16eb4cb64833292b73d5d95f4c3fc