### PR TITLE
refactor: use uppercase config access

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any, Dict
+from omegaconf import DictConfig
 
 from .kinetics_400 import Kinetics400
 from .kinetics_400_cached import Kinetics400Cached
@@ -13,7 +14,7 @@ _DATASETS = {
 }
 
 
-def build_dataset(config: Dict[str, Any]):
+def build_dataset(config: DictConfig):
     """Build a dataset from a configuration dictionary.
 
     The configuration must contain a single entry under the ``datasets`` key
@@ -21,11 +22,11 @@ def build_dataset(config: Dict[str, Any]):
     appropriate dataset class.
     """
 
-    datasets_cfg = config.get("datasets", {})
+    datasets_cfg = config.DATASETS
     if len(datasets_cfg) != 1:
         raise ValueError("Config must contain exactly one dataset specification")
 
-    name = next(iter(datasets_cfg))
+    name = next(iter(datasets_cfg)).lower()
     if name not in _DATASETS:
         raise ValueError(f"Unsupported dataset: {name}")
 

--- a/datasets/kinetics_400.py
+++ b/datasets/kinetics_400.py
@@ -48,9 +48,9 @@ class Kinetics400(Dataset):
 
     def __init__(self, config) -> None:
         self.config = config
-        self.csv_path = str(config["datasets"]["kinetics_400"]["paths"]["csv"])
-        self.n_frame = int(config["datasets"]["kinetics_400"]["n_frame"])
-        self.stride = int(config["datasets"]["kinetics_400"]["stride"])
+        self.csv_path = str(config.DATASETS.KINETICS_400.PATHS.CSV)
+        self.n_frame = int(config.DATASETS.KINETICS_400.N_FRAME)
+        self.stride = int(config.DATASETS.KINETICS_400.STRIDE)
         self.dataframe = pd.read_csv(self.csv_path, header=None, names=["video_path", "index"], sep=" ")
 
     def __len__(self) -> int:  # pragma: no cover - simple wrapper

--- a/datasets/kinetics_400_cached.py
+++ b/datasets/kinetics_400_cached.py
@@ -21,9 +21,9 @@ class Kinetics400Cached(Dataset):
 
     def __init__(self, config) -> None:
         self.config = config
-        cfg = config["datasets"]["kinetics_400_cached"]
-        self.metadata_path = str(cfg["paths"]["metadata"])
-        self.path_col = str(cfg.get("path_col", "out_path"))
+        cfg = config.DATASETS.KINETICS_400_CACHED
+        self.metadata_path = str(cfg.PATHS.METADATA)
+        self.path_col = str(cfg.PATH_COL)
 
         self.df_metadata = pd.read_csv(self.metadata_path)
         self.metadata_list_dict = [

--- a/models/latent_video_model.py
+++ b/models/latent_video_model.py
@@ -30,8 +30,8 @@ class LatentVideoModel(nn.Module):
         super().__init__()
         self.config = config
         # Backbone encoder producing latent representations (optional)
-        backbone_cfg = config.get("backbone", {})
-        hf_repo = backbone_cfg.get("hf_repo")
+        backbone_cfg = config.BACKBONE
+        hf_repo = getattr(backbone_cfg, "HF_REPO", None)
         if hf_repo:
             self.encoder = AutoModel.from_pretrained(hf_repo)
             # Use the original Hugging Face video preprocessor tied to the encoder
@@ -42,11 +42,11 @@ class LatentVideoModel(nn.Module):
             self.preprocessor = None
             logger.info("No backbone encoder, operating directly on latents")
         # Flow matching transformer component
-        fm_cfg = config.get("flow_matching", {})
-        dit_cfg = fm_cfg.get("dit", {})
+        fm_cfg = config.FLOW_MATCHING
+        dit_cfg = getattr(fm_cfg, "DIT", None) or {}
         self.flow_transformer = DiT(**dit_cfg) if dit_cfg else None
         # Configure whether the encoder should be trainable
-        trainable = config.get("encoder_trainable", False)
+        trainable = config.ENCODER_TRAINABLE
         self.set_encoder_trainable(trainable)
 
     # ------------------------------------------------------------------

--- a/src/main.py
+++ b/src/main.py
@@ -28,30 +28,24 @@ def main() -> None:
 
     model.count_parameters()
 
-    learning_rate = float(config["trainer"]["learning_rate"])
-    weight_decay = float(config["trainer"]["weight_decay"])
+    learning_rate = float(config.TRAINER.LEARNING_RATE)
+    weight_decay = float(config.TRAINER.WEIGHT_DECAY)
     optimizer = torch.optim.AdamW(
         model.parameters(), lr=learning_rate, weight_decay=weight_decay
     )
     scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer)
 
-    num_workers = int(config["trainer"]["num_workers"])
+    num_workers = int(config.TRAINER.NUM_WORKERS)
     dataloader = torch.utils.data.DataLoader(
         dataset, shuffle=True, num_workers=num_workers
     )
 
-    num_train_timesteps = int(
-        config['flow_matching'].get("num_train_timesteps", 1000)
-    )
+    num_train_timesteps = int(config.FLOW_MATCHING.NUM_TRAIN_TIMESTEPS)
     noise_scheduler = DDPMScheduler(num_train_timesteps=num_train_timesteps)
 
-    gradient_accumulation_steps = int(
-        config["trainer"].get("gradient_accumulation_steps", 1)
-    )
-    find_unused_parameters = bool(
-        config["trainer"].get("find_unused_parameters", False)
-    )
-    mixed_precision = str(config["trainer"].get("mixed_precision", "no"))
+    gradient_accumulation_steps = int(config.TRAINER.GRADIENT_ACCUMULATION_STEPS)
+    find_unused_parameters = bool(config.TRAINER.FIND_UNUSED_PARAMETERS)
+    mixed_precision = str(config.TRAINER.MIXED_PRECISION)
 
     accelerator = Accelerator(
         gradient_accumulation_steps=gradient_accumulation_steps,
@@ -79,7 +73,7 @@ def main() -> None:
         logger=logger,
     )
 
-    eval_every = int(config.get("evaluation", {}).get("eval_every", 1))
+    eval_every = int(config.EVALUATION.EVAL_EVERY)
     trainer.fit(dataloader, epochs=1, eval_every=eval_every)
 
 


### PR DESCRIPTION
## Summary
- convert loaded configs to use uppercase keys for attribute access
- update datasets, model, and entrypoint to read configuration via uppercase attributes

## Testing
- `python -m py_compile utils/config.py src/main.py datasets/kinetics_400.py datasets/kinetics_400_cached.py datasets/__init__.py models/latent_video_model.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32c3ac2888332a0438b86b430c27d