### PR TITLE
Add optional gradient checkpointing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Run `utils.config.load_config` to resolve the hierarchy and `utils.config.print_
 
 The training configuration additionally supports a `mixed_precision` field
 (`"no"`, `"fp16"` or `"bf16"`) that is forwarded to the Hugging Face
-`Accelerator` for mixed precision training.
+`Accelerator` for mixed precision training. A `gradient_checkpointing` flag
+enables PyTorch's gradient checkpointing for reduced memory usage.
 
 ### Flow matching
 

--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -5,3 +5,4 @@ trainer:
   gradient_accumulation_steps: 1
   find_unused_parameters: false
   mixed_precision: bf16
+  gradient_checkpointing: false

--- a/models/latent_video_model.py
+++ b/models/latent_video_model.py
@@ -47,7 +47,10 @@ class LatentVideoModel(nn.Module):
         # Config files may specify DIT parameters using upper-case keys.
         # Normalize keys to match the DiT constructor signature.
         dit_cfg = {k.lower(): v for k, v in dit_cfg.items()}
+        gc = bool(getattr(config.TRAINER, "GRADIENT_CHECKPOINTING", False))
+        dit_cfg["gradient_checkpointing"] = gc
         self.flow_transformer = DiT(**dit_cfg) if dit_cfg else None
+        self.gradient_checkpointing = gc
         # Configure whether the encoder should be trainable
         trainable = config.ENCODER_TRAINABLE
         self.set_encoder_trainable(trainable)


### PR DESCRIPTION
## Summary
- add gradient_checkpointing flag to training config
- enable checkpointing for DiT blocks when flag is set
- document gradient checkpointing option

## Testing
- `python -m py_compile models/DiT.py models/latent_video_model.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b339c6a8048332a34bb4f1b0282572