### PR TITLE
Add automatic attention backend selection

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -6,20 +6,16 @@ This directory contains the model components used by FutureLatents.
   flow matching transformer operating on latent tokens.
 - `DiT.py` implements a minimal diffusion transformer (DiT) that predicts
   the noise added at each training timestep.  It uses PyTorch's
-  ``scaled_dot_product_attention`` with optional flash or efficient
-  attention backends selected via the ``attn_backends`` argument.
-  For example:
+  ``scaled_dot_product_attention`` with a context manager that
+  automatically selects the best available backend.  Flash attention is
+  preferred, followed by the XFormers memory‑efficient kernel and a math
+  fallback:
 
   ```python
   from torch.nn.functional import scaled_dot_product_attention
-  from torch.nn.attention import SDPBackend, sdpa_kernel
+  from utils.attention import sdpa_auto_backend
 
-  # Only enable flash attention backend
-  with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
-      scaled_dot_product_attention(...)
-
-  # Enable the Math or Efficient attention backends
-  with sdpa_kernel([SDPBackend.MATH, SDPBackend.EFFICIENT_ATTENTION]):
+  with sdpa_auto_backend():
       scaled_dot_product_attention(...)
   ```
 

--- a/utils/attention.py
+++ b/utils/attention.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterable
+
+import torch
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+
+def _available_backends() -> SDPBackend | list[SDPBackend]:
+    """Return the optimal attention backend(s) for the current environment.
+
+    Preference order is Flash Attention > Efficient Attention > Math fallback.
+    The function inspects the PyTorch CUDA SDP utilities to determine which
+    kernels are compiled and enabled.  When neither specialised kernel is
+    available the math implementation is used as a safe default.
+    """
+
+    # Prefer flash attention when compiled and enabled
+    if torch.backends.cuda.flash_sdp_enabled():
+        return SDPBackend.FLASH_ATTENTION
+
+    backends: list[SDPBackend] = []
+    if torch.backends.cuda.mem_efficient_sdp_enabled():
+        backends.append(SDPBackend.EFFICIENT_ATTENTION)
+    backends.append(SDPBackend.MATH)
+    return backends
+
+
+@contextmanager
+def sdpa_auto_backend() -> Iterable[None]:
+    """Context manager selecting the best attention backend automatically."""
+    with sdpa_kernel(_available_backends()):
+        yield


### PR DESCRIPTION
## Summary
- add `sdpa_auto_backend` context manager to automatically choose flash, efficient or math attention kernels
- simplify `DiT` implementation to use the automatic backend and drop config-based selection
- document new attention backend selection approach

## Testing
- `python -m py_compile utils/attention.py models/DiT.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b473a0545c83329947e8d7559d5c96