### PR TITLE
Fix attention backend selection for older GPUs

### DIFF
--- a/utils/attention.py
+++ b/utils/attention.py
@@ -7,20 +7,23 @@ import torch
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 
-def _available_backends() -> SDPBackend | list[SDPBackend]:
-    """Return the optimal attention backend(s) for the current environment.
+def _available_backends() -> list[SDPBackend]:
+    """Return attention backends in preference order.
 
-    Preference order is Flash Attention > Efficient Attention > Math fallback.
-    The function inspects the PyTorch CUDA SDP utilities to determine which
-    kernels are compiled and enabled.  When neither specialised kernel is
-    available the math implementation is used as a safe default.
+    The function inspects which scaled dot-product attention (SDPA) kernels are
+    *enabled* in the current PyTorch environment and returns them ordered by
+    preference: Flash Attention > Memory Efficient Attention > math fallback.
+
+    Returning a list rather than a single backend allows PyTorch to gracefully
+    fall back to a supported kernel when higher-priority implementations are not
+    available at run time (e.g. when the GPU architecture does not support Flash
+    Attention).  This avoids ``RuntimeError: No available kernel`` failures on
+    older GPUs.
     """
 
-    # Prefer flash attention when compiled and enabled
-    if torch.backends.cuda.flash_sdp_enabled():
-        return SDPBackend.FLASH_ATTENTION
-
     backends: list[SDPBackend] = []
+    if torch.backends.cuda.flash_sdp_enabled():
+        backends.append(SDPBackend.FLASH_ATTENTION)
     if torch.backends.cuda.mem_efficient_sdp_enabled():
         backends.append(SDPBackend.EFFICIENT_ATTENTION)
     backends.append(SDPBackend.MATH)


### PR DESCRIPTION
## Summary
- return all enabled attention backends in preference order
- document fallback behaviour to avoid `No available kernel` runtime error on unsupported GPUs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b47613a2a483329c2f6405443c6739