### PR TITLE
Use Accelerator for gradient clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ Run `utils.config.load_config` to resolve the hierarchy and `utils.config.print_
 The training configuration additionally supports a `mixed_precision` field
 (`"no"`, `"fp16"` or `"bf16"`) that is forwarded to the Hugging Face
 `Accelerator` for mixed precision training. A `gradient_checkpointing` flag
-enables PyTorch's gradient checkpointing for reduced memory usage.
+enables PyTorch's gradient checkpointing for reduced memory usage. Optional
+`max_grad_norm` and `max_grad_value` settings clip gradients via the
+accelerator to stabilise training.
 
 ### Flow matching
 

--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -6,3 +6,5 @@ trainer:
   find_unused_parameters: false
   mixed_precision: fp16
   gradient_checkpointing: true
+  max_grad_norm: 1.0
+  max_grad_value: null

--- a/src/main.py
+++ b/src/main.py
@@ -60,11 +60,16 @@ def main() -> None:
     logging.basicConfig(level=logging.INFO)
     logger = logging.getLogger(__name__)
 
+    max_grad_norm = getattr(config.TRAINER, "MAX_GRAD_NORM", None)
+    max_grad_value = getattr(config.TRAINER, "MAX_GRAD_VALUE", None)
+
     trainer = Trainer(
         model,
         optimizer,
         scheduler,
         accelerator=accelerator,
+        max_grad_norm=float(max_grad_norm) if max_grad_norm is not None else None,
+        max_grad_value=float(max_grad_value) if max_grad_value is not None else None,
         logger=logger,
     )
 


### PR DESCRIPTION
## Summary
- allow optional gradient clipping via Accelerator
- document gradient clipping options and add defaults in trainer config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b555281c1c83329fba29c137057b8d