### PR TITLE
Include label merging for Kinetics-400 dataset

### DIFF
--- a/configs/datasets/kinetics_400.yaml
+++ b/configs/datasets/kinetics_400.yaml
@@ -5,3 +5,4 @@ datasets:
     paths:
       train_csv: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_train_paths.csv
       val_csv: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_val_paths.csv
+      labels_txt: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_labels.txt


### PR DESCRIPTION
## Summary
- load Kinetics-400 label file and merge with train/val CSV annotations
- expose merged label in dataset items
- add label path to Kinetics-400 dataset config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b897c56cac8332bb04d1eef4cdd6d2