### PR TITLE
Configure evaluation schedule within Trainer

### DIFF
--- a/configs/training/evaluation.yaml
+++ b/configs/training/evaluation.yaml
@@ -1,2 +1,3 @@
 evaluation:
   eval_every: 1
+  eval_first: false

--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -8,3 +8,4 @@ trainer:
   gradient_checkpointing: true
   max_grad_norm: 1.0
   max_grad_value: null
+  epochs: 1

--- a/src/main.py
+++ b/src/main.py
@@ -96,11 +96,12 @@ def main() -> None:
         accelerator=accelerator,
         max_grad_norm=float(max_grad_norm) if max_grad_norm is not None else None,
         max_grad_value=float(max_grad_value) if max_grad_value is not None else None,
+        config=config,
         logger=logger,
     )
 
-    eval_every = int(config.EVALUATION.EVAL_EVERY)
-    trainer.fit(train_dataloader, val_dataloader, epochs=1, eval_every=eval_every)
+    epochs = int(config.TRAINER.EPOCHS)
+    trainer.fit(train_dataloader, val_dataloader, epochs=epochs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- move evaluation settings into `Trainer` initialization and read directly from config
- train duration configured via `TRAINER.EPOCHS`

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`
- `python -m py_compile training/trainer.py src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b89962bf748332a109822a000c0a13