### PR TITLE
Merge training and evaluation configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,14 @@ notebooks/ Exploratory notebooks (empty placeholder)
 ## Configuration
 
 Configurations can be composed using the `inherits` key. For example
-`configs/vjepa2_kinetics_400.yaml` combines dataset, backbone, training, evaluation
-and flow‑matching settings:
+`configs/vjepa2_kinetics_400.yaml` combines dataset, backbone, training and
+flow‑matching settings:
 
 ```yaml
 inherits:
   - datasets/kinetics_400.yaml
   - backbones/vjepa2.yaml
   - training/trainer.yaml
-  - training/evaluation.yaml
   - training/flow_matching.yaml
 encoder_trainable: false
 ```

--- a/configs/training/evaluation.yaml
+++ b/configs/training/evaluation.yaml
@@ -1,3 +1,0 @@
-evaluation:
-  eval_every: 1
-  eval_first: false

--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -1,11 +1,15 @@
 trainer:
-  learning_rate: 1e-5
-  weight_decay: 0.01
-  num_workers: 8
-  gradient_accumulation_steps: 1
-  find_unused_parameters: false
-  mixed_precision: fp16
-  gradient_checkpointing: true
-  max_grad_norm: 1.0
-  max_grad_value: null
-  epochs: 1
+  training:
+    learning_rate: 1e-5
+    weight_decay: 0.01
+    num_workers: 8
+    gradient_accumulation_steps: 1
+    find_unused_parameters: false
+    mixed_precision: fp16
+    gradient_checkpointing: true
+    max_grad_norm: 1.0
+    max_grad_value: null
+    epochs: 1
+  evaluation:
+    eval_every: 1
+    eval_first: false

--- a/configs/vjepa2_kinetics_400.yaml
+++ b/configs/vjepa2_kinetics_400.yaml
@@ -2,6 +2,5 @@ inherits:
   - datasets/kinetics_400.yaml
   - backbones/vjepa2.yaml
   - training/trainer.yaml
-  - training/evaluation.yaml
   - training/flow_matching.yaml
 encoder_trainable: false

--- a/configs/vjepa2_kinetics_400_cached.yaml
+++ b/configs/vjepa2_kinetics_400_cached.yaml
@@ -1,7 +1,6 @@
 inherits:
   - datasets/kinetics_400_cached.yaml
   - training/trainer.yaml
-  - training/evaluation.yaml
   - training/flow_matching.yaml
 encoder_trainable: false
 backbone: null

--- a/models/latent_video_model.py
+++ b/models/latent_video_model.py
@@ -49,7 +49,7 @@ class LatentVideoModel(nn.Module):
         # Config files may specify DIT parameters using upper-case keys.
         # Normalize keys to match the DiT constructor signature.
         dit_cfg = {k.lower(): v for k, v in dit_cfg.items()}
-        gc = config.TRAINER.GRADIENT_CHECKPOINTING
+        gc = config.TRAINER.TRAINING.GRADIENT_CHECKPOINTING
         dit_cfg["gradient_checkpointing"] = gc
         self.flow_transformer = DiT(**dit_cfg) if dit_cfg else None
         self.gradient_checkpointing = gc

--- a/src/main.py
+++ b/src/main.py
@@ -35,14 +35,14 @@ def main() -> None:
 
     model = LatentVideoModel(config)
 
-    learning_rate = float(config.TRAINER.LEARNING_RATE)
-    weight_decay = float(config.TRAINER.WEIGHT_DECAY)
+    learning_rate = float(config.TRAINER.TRAINING.LEARNING_RATE)
+    weight_decay = float(config.TRAINER.TRAINING.WEIGHT_DECAY)
     optimizer = torch.optim.AdamW(
         model.parameters(), lr=learning_rate, weight_decay=weight_decay
     )
     scheduler = torch.optim.lr_scheduler.ConstantLR(optimizer)
 
-    num_workers = int(config.TRAINER.NUM_WORKERS)
+    num_workers = int(config.TRAINER.TRAINING.NUM_WORKERS)
     train_dataloader = torch.utils.data.DataLoader(
         train_dataset, shuffle=True, num_workers=num_workers
     )
@@ -50,9 +50,13 @@ def main() -> None:
         val_dataset, shuffle=False, num_workers=num_workers
     )
 
-    gradient_accumulation_steps = int(config.TRAINER.GRADIENT_ACCUMULATION_STEPS)
-    find_unused_parameters = bool(config.TRAINER.FIND_UNUSED_PARAMETERS)
-    mixed_precision = str(config.TRAINER.MIXED_PRECISION)
+    gradient_accumulation_steps = int(
+        config.TRAINER.TRAINING.GRADIENT_ACCUMULATION_STEPS
+    )
+    find_unused_parameters = bool(
+        config.TRAINER.TRAINING.FIND_UNUSED_PARAMETERS
+    )
+    mixed_precision = str(config.TRAINER.TRAINING.MIXED_PRECISION)
 
     accelerator = Accelerator(
         gradient_accumulation_steps=gradient_accumulation_steps,
@@ -77,8 +81,8 @@ def main() -> None:
 
 
 
-    max_grad_norm = config.TRAINER.MAX_GRAD_NORM
-    max_grad_value = config.TRAINER.MAX_GRAD_VALUE
+    max_grad_norm = config.TRAINER.TRAINING.MAX_GRAD_NORM
+    max_grad_value = config.TRAINER.TRAINING.MAX_GRAD_VALUE
     if max_grad_norm is None and max_grad_value is None:
         raise ValueError(
             "Either MAX_GRAD_NORM or MAX_GRAD_VALUE must be specified in the config"
@@ -92,7 +96,7 @@ def main() -> None:
     trainer = Trainer(
         model=model,
         optimizer=optimizer,
-        config=config,
+        config=config.TRAINER,
         scheduler=scheduler,
         accelerator=accelerator,
         max_grad_norm=float(max_grad_norm) if max_grad_norm is not None else None,
@@ -100,8 +104,7 @@ def main() -> None:
         logger=logger,
     )
 
-    epochs = int(config.TRAINER.EPOCHS)
-    trainer.fit(train_dataloader, val_dataloader, epochs=epochs)
+    trainer.fit(train_dataloader, val_dataloader)
 
 
 if __name__ == "__main__":

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -43,7 +43,7 @@ class Trainer:
     max_grad_value:
         If specified, clip gradients to this maximum absolute value.
     config:
-        Configuration object holding evaluation parameters.
+        Configuration object holding training and evaluation parameters.
     """
 
     def __init__(
@@ -67,6 +67,7 @@ class Trainer:
         self.logger = logger or logging.getLogger(__name__)
         self.eval_every = int(config.EVALUATION.EVAL_EVERY)
         self.eval_first = bool(config.EVALUATION.EVAL_FIRST)
+        self.epochs = int(config.TRAINING.EPOCHS)
 
     # ------------------------------------------------------------------
     # Training utilities
@@ -159,7 +160,7 @@ class Trainer:
         self,
         train_loader: Iterable[dict],
         val_loader: Optional[Iterable[dict]] = None,
-        epochs: int = 1,
+        epochs: Optional[int] = None,
         checkpoint_dir: Optional[str] = None,
         save_every: int = 1,
     ) -> None:
@@ -172,7 +173,8 @@ class Trainer:
         val_loader:
             Optional dataloader used for evaluation.
         epochs:
-            Total number of epochs to train for.
+            Total number of epochs to train for. If ``None``, the value from
+            the configuration is used.
         checkpoint_dir:
             Directory to store checkpoints in.  If ``None`` no checkpoints are
             written.
@@ -189,6 +191,9 @@ class Trainer:
         ckpt_path: Optional[Path] = Path(checkpoint_dir) if checkpoint_dir else None
         if ckpt_path is not None:
             ckpt_path.mkdir(parents=True, exist_ok=True)
+
+        if epochs is None:
+            epochs = self.epochs
 
         if self.eval_first and val_loader is not None:
             val_loss = self.val(val_loader)


### PR DESCRIPTION
## Summary
- Merge trainer and evaluation YAML files into a single trainer configuration with `training` and `evaluation` sections
- Read training parameters from the new config locations throughout code and move epoch retrieval into `Trainer`
- Update example configs and documentation for consolidated training setup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b89cce28888332bc68b508f6b90290