### PR TITLE
Add optional W&B logging and context conditioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ venv/
 
 # MacOS
 .DS_Store
+
+# W&B logs
+wandb/

--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -1,3 +1,4 @@
+wandb: true
 trainer:
   training:
     learning_rate: 1e-5


### PR DESCRIPTION
## Summary
- gate W&B tracking behind new `WANDB` config flag
- incorporate context latents via AdaLN in DiT backbone
- ignore generated W&B logs in git

## Testing
- `python -m py_compile models/DiT.py src/main.py utils/config.py training/trainer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9842b38d083328d440bf07bc862b4