### PR TITLE
feat: add optional embedding normalisation

### DIFF
--- a/configs/training/trainer.yaml
+++ b/configs/training/trainer.yaml
@@ -11,6 +11,7 @@ trainer:
     max_grad_norm: 1.0
     max_grad_value: null
     epochs: 1
+    normalize_embeddings: false
   evaluation:
     eval_every: 1
     eval_first: false


### PR DESCRIPTION
## Summary
- add `normalize_embeddings` option in training config
- support optional L2 normalisation of VJEPA2 context and target embeddings in `LatentVideoModel`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bebe8c64088332ba17dcd9cf4ca467