### PR TITLE
Refactor PredictorTransformer to self-attention on context

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -145,7 +145,7 @@ class DeterministicLatentVideoModel(LatentVideoBase):
         context_latents = rearrange(context_latents, "b d t h w -> b (t h w) d")
         target_latents  = rearrange(target_latents,  "b d t h w -> b (t h w) d")
 
-        prediction = self.predictor(context_latents, target_latents)  # direct next-token prediction
+        prediction = self.predictor(context_latents)  # direct next-token prediction
         return prediction, target_latents
 
     def trainable_modules(self) -> Iterable[nn.Module]:  # optional: curated list


### PR DESCRIPTION
## Summary
- simplify PredictorBlock to pure self-attention + MLP
- refactor PredictorTransformer to process only context tokens via self-attention
- adjust DeterministicLatentVideoModel for updated predictor API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c00eb1c0f88332adfc372ff10f02e4