### PR TITLE
Limit steps and checkpoint each epoch

### DIFF
--- a/configs/vjepa2_kinetics_400_deterministic.yaml
+++ b/configs/vjepa2_kinetics_400_deterministic.yaml
@@ -3,3 +3,10 @@ inherits:
   - backbones/vjepa2.yaml
   - training/trainer_deterministic.yaml
 encoder_trainable: false
+trainer:
+  training:
+    max_steps: 1000
+    checkpoint_dir: checkpoints
+    save_every: 1
+  evaluation:
+    max_videos: 100

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -270,9 +270,9 @@ class Trainer:
             ):
                 wandb.log(epoch_log, step=self.state.step)
 
-        if ckpt_path is not None and (epoch + 1) % save_every == 0:
-            filename = ckpt_path / f"checkpoint_epoch_{epoch + 1}.pt"
-            self.save_checkpoint(filename)
+            if ckpt_path is not None and (epoch + 1) % save_every == 0:
+                filename = ckpt_path / f"checkpoint_epoch_{epoch + 1}.pt"
+                self.save_checkpoint(filename)
 
 
 class DeterministicTrainer(Trainer):


### PR DESCRIPTION
## Summary
- restrict training to a configurable number of steps and evaluation videos
- save checkpoints at the end of every epoch
- add experiment settings for a short deterministic Kinetics-400 run

## Testing
- `python -m py_compile training/trainer.py src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0105c256483328006f83c44c5d553