### PR TITLE
Add Slurm job script for vjepa2 Kinetics training

### DIFF
--- a/jobs/vjepa2_kinetics_job.sh
+++ b/jobs/vjepa2_kinetics_job.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=vjepa2_kinetics
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=8
+#SBATCH --gpus-per-node=8
+#SBATCH --time=24:00:00
+#SBATCH --partition=gpu
+
+set -e
+
+source ~/.bashrc
+conda activate future_latents
+
+srun accelerate launch --num_processes 8 --num_machines 1 -m src.main \
+  --config_path configs/vjepa2_kinetics_400_deterministic.yaml


### PR DESCRIPTION
## Summary
- add `jobs/vjepa2_kinetics_job.sh` for launching training via Slurm on 1 node with 8 GPUs

## Testing
- `bash -n jobs/vjepa2_kinetics_job.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0167852008332ad343fa4f4fb2c4e