### PR TITLE
Ensure slurm logs moved to experiment directory

### DIFF
--- a/jobs/vjepa2_kinetics_job_deterministic.sh
+++ b/jobs/vjepa2_kinetics_job_deterministic.sh
@@ -14,20 +14,29 @@ set -e
 
 ROOT=/private/home/francoisporcher/FutureLatents
 CONFIG_PATH=configs/vjepa2_kinetics_400_deterministic.yaml
-CONFIG_NAME=$(basename "$CONFIG_PATH" .yaml)
-EXPERIMENT_DIR="$ROOT/experiment/$CONFIG_NAME"
+JOB_NAME=$(basename "$0" .sh)
+EXPERIMENT_DIR="$ROOT/experiment/$JOB_NAME"
 SLURM_LOG_DIR="$EXPERIMENT_DIR/slurm"
+
+echo "ROOT: $ROOT"
+echo "CONFIG_PATH: $CONFIG_PATH"
+echo "JOB_NAME: $JOB_NAME"
+echo "EXPERIMENT_DIR: $EXPERIMENT_DIR"
+echo "SLURM_LOG_DIR: $SLURM_LOG_DIR"
 
 # Prepare experiment directory for SLURM logs
 mkdir -p "$SLURM_LOG_DIR"
-if [ -n "$SLURM_JOB_ID" ]; then
-  OUT_FILE="$ROOT/${CONFIG_NAME}_${SLURM_JOB_ID}.out"
-  ERR_FILE="$ROOT/${CONFIG_NAME}_${SLURM_JOB_ID}.err"
+
+move_logs() {
+  OUT_FILE="$SLURM_SUBMIT_DIR/${SLURM_JOB_NAME}_${SLURM_JOB_ID}.out"
+  ERR_FILE="$SLURM_SUBMIT_DIR/${SLURM_JOB_NAME}_${SLURM_JOB_ID}.err"
   [ -f "$OUT_FILE" ] && mv "$OUT_FILE" "$SLURM_LOG_DIR/"
   [ -f "$ERR_FILE" ] && mv "$ERR_FILE" "$SLURM_LOG_DIR/"
-fi
+}
+trap move_logs EXIT
 
 cd "$ROOT"
+echo "Current directory: $(pwd)"
 
 # Silence bind warnings from non-interactive shells
 source ~/.bashrc >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- move Slurm stdout/stderr to experiment/<job_name>/slurm on job exit
- print job variables and current directory for easier debugging

## Testing
- `bash -n jobs/vjepa2_kinetics_job_deterministic.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c029859fbc83328d71a3f23e91cfad