### PR TITLE
Redirect evaluation logs to stdout

### DIFF
--- a/jobs/vjepa2_kinetics_job_deterministic.sh
+++ b/jobs/vjepa2_kinetics_job_deterministic.sh
@@ -45,5 +45,7 @@ python --version
 nvidia-smi || true  # don't fail job if nvidia-smi is restricted
 
 # Use Slurm’s task count to drive accelerate; let Slurm place tasks
+# Redirect stderr to stdout so evaluation logs go to the .out file
 accelerate launch --num_processes 8 --num_machines 1 -m src.main \
---config_path "$CONFIG_PATH"
+--config_path "$CONFIG_PATH" 2>&1
+


### PR DESCRIPTION
## Summary
- redirect evaluation logs to stdout in `vjepa2_kinetics_job_deterministic.sh`
- add comment about redirection

## Testing
- `shellcheck jobs/vjepa2_kinetics_job_deterministic.sh` *(fails: command not found)*
- `bash -n jobs/vjepa2_kinetics_job_deterministic.sh`


------
https://chatgpt.com/codex/tasks/task_e_68c04ba7eee883329078370af9f39cc3