### PR TITLE
Move save_every retrieval into Trainer

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -137,13 +137,10 @@ def main() -> None:
     )
 
     checkpoint_dir = checkpoints_dir
-    save_every = int(config.TRAINER.TRAINING.get("SAVE_EVERY", 1))
-
     trainer.fit(
         train_dataloader,
         val_dataloader,
         checkpoint_dir=checkpoint_dir,
-        save_every=save_every,
     )
 
     if accelerator.is_main_process and use_wandb and wandb.run is not None:

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -87,6 +87,7 @@ class Trainer:
         self.max_grad_norm = config.TRAINING.MAX_GRAD_NORM
         self.max_grad_value = config.TRAINING.MAX_GRAD_VALUE
         self.criterion = get_criterion(str(config.TRAINING.LOSS))
+        self.save_every = int(config.TRAINING.SAVE_EVERY)
         
 
         if self.max_grad_norm is None and self.max_grad_value is None:
@@ -236,7 +237,6 @@ class Trainer:
         val_loader: Optional[Iterable[dict]] = None,
         epochs: Optional[int] = None,
         checkpoint_dir: Optional[str] = None,
-        save_every: int = 1,
     ) -> None:
         """Run the training loop for ``epochs`` epochs.
 
@@ -252,9 +252,7 @@ class Trainer:
         checkpoint_dir:
             Directory to store checkpoints in.  If ``None`` no checkpoints are
             written.
-        save_every:
-            Save a checkpoint every ``save_every`` epochs.
-        
+
         Notes
         -----
         Evaluation frequency is controlled by ``self.eval_every`` set during
@@ -304,7 +302,7 @@ class Trainer:
 
             if (
                 ckpt_path is not None
-                and (epoch + 1) % save_every == 0
+                and (epoch + 1) % self.save_every == 0
                 and (
                     self.accelerator is None or self.accelerator.is_main_process
                 )


### PR DESCRIPTION
## Summary
- Load checkpoint save frequency from trainer config within Trainer
- Simplify main by removing SAVE_EVERY access and parameter

## Testing
- `python -m py_compile src/main.py training/trainer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c050fb5718833299f98a28625a586b