### PR TITLE
refactor: add trainer builder

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ import shutil
 # ``PYTHONPATH``.
 from models import build_model
 from datasets import build_dataset
-from training.trainer import Trainer, DeterministicTrainer
+from training import build_trainer
 from utils.parser import create_parser
 from utils.config import load_config, print_config
 import torch
@@ -122,15 +122,10 @@ def main() -> None:
     if accelerator.is_main_process and use_wandb:
         wandb.watch(model, log="gradients", log_freq=500)
 
-    trainer_cls = (
-        DeterministicTrainer
-        if str(config.MODEL.TYPE).lower() == "deterministic"
-        else Trainer
-    )
-    trainer = trainer_cls(
+    trainer = build_trainer(
+        config=config,
         model=model,
         optimizer=optimizer,
-        config=config.TRAINER,
         scheduler=scheduler,
         accelerator=accelerator,
         logger=logger,

--- a/training/__init__.py
+++ b/training/__init__.py
@@ -1,1 +1,68 @@
-"""Training package.\n"""
+"""Training utilities for FutureLatents.
+
+This module exposes the high level :func:`build_trainer` factory alongside the
+concrete trainer implementations.  The factory mirrors the style of the
+``build_model`` and ``build_dataset`` helpers in the project and selects the
+appropriate trainer class based on ``config.MODEL.TYPE``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from .trainer import (
+    DeterministicTrainer,
+    Trainer,
+    TrainState,
+    get_criterion,
+)
+
+
+def build_trainer(
+    config,
+    model,
+    optimizer,
+    scheduler: Optional[object] = None,
+    accelerator: Optional[object] = None,
+    logger: Optional[logging.Logger] = None,
+):
+    """Instantiate a trainer based on ``config.MODEL.TYPE``.
+
+    Parameters
+    ----------
+    config:
+        Full configuration object.  ``config.MODEL.TYPE`` controls which
+        trainer implementation is used.
+    model:
+        The model to be optimised.
+    optimizer:
+        Optimiser responsible for updating the model parameters.
+    scheduler:
+        Optional learning rate scheduler.
+    accelerator:
+        Optional ``accelerate.Accelerator`` used for distributed training.
+    logger:
+        Optional ``logging.Logger`` instance for status messages.
+    """
+
+    trainer_type = str(config.MODEL.TYPE).lower()
+    trainer_cls = DeterministicTrainer if trainer_type == "deterministic" else Trainer
+    return trainer_cls(
+        model=model,
+        optimizer=optimizer,
+        config=config.TRAINER,
+        scheduler=scheduler,
+        accelerator=accelerator,
+        logger=logger,
+    )
+
+
+__all__ = [
+    "Trainer",
+    "TrainState",
+    "DeterministicTrainer",
+    "get_criterion",
+    "build_trainer",
+]
+


### PR DESCRIPTION
## Summary
- add build_trainer factory to centralize trainer selection
- simplify main pipeline to use build_trainer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0519e6da4833295c1c11494058c38