### PR TITLE
Use config-based experiment directories

### DIFF
--- a/jobs/train_vjepa2_kinetics_400_deterministic.sh
+++ b/jobs/train_vjepa2_kinetics_400_deterministic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -l
-#SBATCH --job-name=train_vjepa2_kinetics_400_deterministic
+#SBATCH --job-name=vjepa2_kinetics_400_deterministic
 #SBATCH --nodes=2
 #SBATCH --ntasks-per-node=8
 #SBATCH --gpus-per-node=8
@@ -10,13 +10,13 @@
 
 ROOT=/private/home/francoisporcher/FutureLatents
 CONFIG_PATH=configs/vjepa2_kinetics_400_deterministic.yaml
-JOB_NAME=train_vjepa2_kinetics_400_deterministic
-EXPERIMENT_DIR="$ROOT/experiment/$JOB_NAME"
+CONFIG_NAME=$(basename "$CONFIG_PATH" .yaml)
+EXPERIMENT_DIR="$ROOT/experiment/$CONFIG_NAME"
 SLURM_LOG_DIR="$EXPERIMENT_DIR/slurm"
 
 echo "ROOT: $ROOT"
 echo "CONFIG_PATH: $CONFIG_PATH"
-echo "JOB_NAME: $JOB_NAME"
+echo "CONFIG_NAME: $CONFIG_NAME"
 echo "EXPERIMENT_DIR: $EXPERIMENT_DIR"
 echo "SLURM_LOG_DIR: $SLURM_LOG_DIR"
 

--- a/src/main.py
+++ b/src/main.py
@@ -58,10 +58,12 @@ def main() -> None:
     checkpoints_dir = experiment_root / "checkpoints"
     logs_dir = experiment_root / "logs"
     config_dir = experiment_root / "config"
+    slurm_dir = experiment_root / "slurm"
     if accelerator.is_main_process:
         checkpoints_dir.mkdir(parents=True, exist_ok=True)
         logs_dir.mkdir(parents=True, exist_ok=True)
         config_dir.mkdir(parents=True, exist_ok=True)
+        slurm_dir.mkdir(parents=True, exist_ok=True)
     accelerator.wait_for_everyone()
 
     train_dataset = build_dataset(config, split="train")


### PR DESCRIPTION
## Summary
- Drive experiment directories from config file name for consistency
- Ensure `slurm` logs are placed under the config-named experiment folder

## Testing
- `bash -n jobs/train_vjepa2_kinetics_400_deterministic.sh`
- `pytest`
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0599135f48332942acef76efd1180