### PR TITLE
Preserve slurm logs when re-running experiments

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -54,7 +54,13 @@ def main() -> None:
     overwrite_experiment = experiment_root.exists()
     if overwrite_experiment and accelerator.is_main_process:
         print("Overwritting experiment", experiment_root)
-        shutil.rmtree(experiment_root)
+        for path in experiment_root.iterdir():
+            if path.name == "slurm":
+                continue
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
     accelerator.wait_for_everyone()
     checkpoints_dir = experiment_root / "checkpoints"
     logs_dir = experiment_root / "logs"


### PR DESCRIPTION
## Summary
- Avoid deleting the `slurm` log directory when an experiment is rerun
- Clean experiment directory contents while preserving existing Slurm logs

## Testing
- `python -m py_compile src/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c06ee73aec83328c32e0e3f0ba683a