### PR TITLE
Print VJEPA2 embedding norms before normalization

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -106,6 +106,10 @@ class FlowMatchingLatentVideoModel(LatentVideoBase):
     def forward(self, batch: Dict[str, Any]):
         latents = self.encode_inputs(batch)  # [B, D, T, H, W]
         if self.normalize_embeddings:
+            flat = latents.flatten(1)
+            l1_norm = flat.abs().sum(dim=1)
+            l2_norm = flat.norm(p=2, dim=1)
+            print(f"VJEPA-2 embedding norms - L1: {l1_norm.tolist()}, L2: {l2_norm.tolist()}")
             latents = F.normalize(latents, dim=1)
         context_latents, target_latents = self.split_latents(latents)
 
@@ -137,8 +141,12 @@ class DeterministicLatentVideoModel(LatentVideoBase):
 
     def forward(self, batch: Dict[str, Any]):
         latents = self.encode_inputs(batch) # [B, D, T, H, W]
-        
+
         if self.normalize_embeddings:
+            flat = latents.flatten(1)
+            l1_norm = flat.abs().sum(dim=1)
+            l2_norm = flat.norm(p=2, dim=1)
+            print(f"VJEPA-2 embedding norms - L1: {l1_norm.tolist()}, L2: {l2_norm.tolist()}")
             latents = F.normalize(latents, dim=1)
         context_latents, target_latents = self.split_latents(latents)
 


### PR DESCRIPTION
## Summary
- Print L1 and L2 norms of VJEPA-2 embeddings before normalization in `FlowMatchingLatentVideoModel` and `DeterministicLatentVideoModel`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1ccfc60e48332beba9f5d8a96713d