### PR TITLE
Move Kinetics-400 configs into references directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ notebooks/   Exploratory notebooks (empty placeholder)
 ## Configuration
 
 Configurations can be composed using the `inherits` key. For example
-`configs/vjepa2_kinetics_400.yaml` combines dataset, backbone, and training
+`configs/references/vjepa2_kinetics_400.yaml` combines dataset, backbone, and training
 settings (including the model configuration):
 
 ```yaml
 inherits:
-  - datasets/kinetics_400.yaml
-  - backbones/vjepa2.yaml
-  - training/trainer_flow_matching.yaml
+  - ../datasets/kinetics_400.yaml
+  - ../backbones/vjepa2.yaml
+  - ../training/trainer_flow_matching.yaml
 encoder_trainable: false
 ```
 
@@ -91,9 +91,9 @@ configuration.
 Print the resolved configuration, instantiate the dataset and model and set up the optimiser:
 
 ```bash
-python -m src.main --config_path configs/vjepa2_kinetics_400.yaml
+python -m src.main --config_path configs/references/vjepa2_kinetics_400.yaml
 # or the deterministic variant
-python -m src.main --config_path configs/vjepa2_kinetics_400_deterministic.yaml
+python -m src.main --config_path configs/references/vjepa2_kinetics_400_deterministic.yaml
 ```
 
 A minimal training example that freezes the encoder and builds an `AdamW` optimiser over trainable
@@ -111,7 +111,7 @@ Both commands expect that the Kinetics‑400 annotation CSV path in
 If you have already encoded your videos, the repository can train directly on cached features using the `Kinetics400Cached` dataset. The `configs/datasets/kinetics_400_cached.yaml` file expects a metadata CSV where each row contains a path (in the `out_path` column by default) to a saved embedding tensor. Running with
 
 ```bash
-python -m src.main --config_path configs/vjepa2_kinetics_400_cached.yaml
+python -m src.main --config_path configs/references/vjepa2_kinetics_400_cached.yaml
 ```
 
 will load those embeddings with `torch.load` and bypass raw video decoding.

--- a/configs/references/vjepa2_kinetics_400.yaml
+++ b/configs/references/vjepa2_kinetics_400.yaml
@@ -1,0 +1,5 @@
+inherits:
+  - ../datasets/kinetics_400.yaml
+  - ../backbones/vjepa2.yaml
+  - ../training/trainer_flow_matching.yaml
+encoder_trainable: false

--- a/configs/references/vjepa2_kinetics_400_cached.yaml
+++ b/configs/references/vjepa2_kinetics_400_cached.yaml
@@ -1,0 +1,5 @@
+inherits:
+  - ../datasets/kinetics_400_cached.yaml
+  - ../training/trainer_flow_matching.yaml
+encoder_trainable: false
+backbone: null

--- a/configs/references/vjepa2_kinetics_400_deterministic.yaml
+++ b/configs/references/vjepa2_kinetics_400_deterministic.yaml
@@ -1,0 +1,6 @@
+inherits:
+  - ../datasets/kinetics_400.yaml
+  - ../backbones/vjepa2.yaml
+  - ../training/trainer_deterministic.yaml
+encoder_trainable: false
+

--- a/configs/vjepa2_kinetics_400.yaml
+++ b/configs/vjepa2_kinetics_400.yaml
@@ -1,5 +1,0 @@
-inherits:
-  - datasets/kinetics_400.yaml
-  - backbones/vjepa2.yaml
-  - training/trainer_flow_matching.yaml
-encoder_trainable: false

--- a/configs/vjepa2_kinetics_400_cached.yaml
+++ b/configs/vjepa2_kinetics_400_cached.yaml
@@ -1,5 +1,0 @@
-inherits:
-  - datasets/kinetics_400_cached.yaml
-  - training/trainer_flow_matching.yaml
-encoder_trainable: false
-backbone: null

--- a/configs/vjepa2_kinetics_400_deterministic.yaml
+++ b/configs/vjepa2_kinetics_400_deterministic.yaml
@@ -1,6 +1,0 @@
-inherits:
-  - datasets/kinetics_400.yaml
-  - backbones/vjepa2.yaml
-  - training/trainer_deterministic.yaml
-encoder_trainable: false
-

--- a/jobs/train_vjepa2_kinetics_400_deterministic.sh
+++ b/jobs/train_vjepa2_kinetics_400_deterministic.sh
@@ -9,7 +9,7 @@
 #SBATCH --error=/private/home/francoisporcher/FutureLatents/experiment/%x/slurm/%x_%j.err
 
 ROOT=/private/home/francoisporcher/FutureLatents
-CONFIG_PATH=configs/vjepa2_kinetics_400_deterministic.yaml
+CONFIG_PATH=configs/references/vjepa2_kinetics_400_deterministic.yaml
 CONFIG_NAME=$(basename "$CONFIG_PATH" .yaml)
 EXPERIMENT_DIR="$ROOT/experiment/$CONFIG_NAME"
 SLURM_LOG_DIR="$EXPERIMENT_DIR/slurm"

--- a/jobs/train_vjepa2_kinetics_400_deterministic_multi_node.sh
+++ b/jobs/train_vjepa2_kinetics_400_deterministic_multi_node.sh
@@ -12,7 +12,7 @@ set -e
 
 # --- Your paths/config ---
 ROOT=/private/home/francoisporcher/FutureLatents
-CONFIG_PATH=configs/vjepa2_kinetics_400_deterministic.yaml
+CONFIG_PATH=configs/references/vjepa2_kinetics_400_deterministic.yaml
 CONFIG_NAME=$(basename "$CONFIG_PATH" .yaml)
 EXPERIMENT_DIR="$ROOT/experiment/$CONFIG_NAME"
 SLURM_LOG_DIR="$EXPERIMENT_DIR/slurm"

--- a/src/main.py
+++ b/src/main.py
@@ -167,5 +167,5 @@ def main() -> None:
 
 if __name__ == "__main__":
     # run with "accelerate launch --num_processes 2 --num_machines 1 -m src.main \
-    #          --config_path configs/vjepa2_kinetics_400.yaml"
+    #          --config_path configs/references/vjepa2_kinetics_400.yaml"
     main()


### PR DESCRIPTION
## Summary
- Relocate vjepa2 Kinetics-400 configs under `configs/references`
- Fix inherit paths to account for new directory structure
- Update documentation and job scripts to use the new config locations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5973dce2883329d2180068b0f553f