### PR TITLE
feat: add configurable embedding norm

### DIFF
--- a/configs/training/trainer_deterministic.yaml
+++ b/configs/training/trainer_deterministic.yaml
@@ -13,7 +13,7 @@ trainer:
     max_grad_norm: 1.0
     max_grad_value: null
     epochs: 12
-    normalize_embeddings: true
+    embedding_norm: l2
     loss: l1
     checkpoint_dir: checkpoints
     save_every: 4

--- a/configs/training/trainer_flow_matching.yaml
+++ b/configs/training/trainer_flow_matching.yaml
@@ -13,7 +13,7 @@ trainer:
     max_grad_norm: 1.0
     max_grad_value: null
     epochs: 1
-    normalize_embeddings: true
+    embedding_norm: l2
     loss: mse
   evaluation:
     eval_every: 1


### PR DESCRIPTION
## Summary
- unify backbone naming with `backbone_type`
- add helper to apply optional L1, L2, or layer norm to encoder outputs
- expose new `embedding_norm` option in training configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a02fc5f483329cdd4203acf9e07b