### PR TITLE
Dump sample videos and latents for visualisation

### DIFF
--- a/notebooks/visualise_dumps.ipynb
+++ b/notebooks/visualise_dumps.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dump visualisation\n",
+    "Load training dumps and visualise DINOv3 latents alongside model predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "from einops import rearrange\n",
+    "from sklearn.decomposition import PCA\n",
+    "import imageio.v2 as imageio\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "dump_root = Path('experiments/dumps')\n",
+    "sample_root = sorted(dump_root.glob('*_epoch_*'))[0]\n",
+    "video = torch.load(sample_root / 'video.pt').numpy()\n",
+    "context_latents = torch.load(sample_root / 'context_latents.pt')\n",
+    "target_latents = torch.load(sample_root / 'target_latents.pt')\n",
+    "prediction = torch.load(sample_root / 'prediction.pt')\n",
+    "\n",
+    "stride = 2\n",
+    "video = np.transpose(video, (0, 2, 3, 1))\n",
+    "video_stride = video[::stride]\n",
+    "\n",
+    "def flatten(x):\n",
+    "    return rearrange(x, 'd t h w -> (t h w) d')\n",
+    "\n",
+    "all_latents = torch.cat([flatten(context_latents), flatten(target_latents), flatten(prediction)], dim=0)\n",
+    "pca = PCA(n_components=3)\n",
+    "pca.fit(all_latents.numpy())\n",
+    "\n",
+    "def to_rgb(x):\n",
+    "    flat = pca.transform(flatten(x).numpy())\n",
+    "    flat = (flat - flat.min()) / (flat.max() - flat.min() + 1e-8)\n",
+    "    t, h, w = x.shape[1:]\n",
+    "    return flat.reshape(t, h, w, 3)\n",
+    "\n",
+    "context_rgb = to_rgb(context_latents)\n",
+    "target_rgb = to_rgb(target_latents)\n",
+    "pred_rgb = to_rgb(prediction)\n",
+    "\n",
+    "frames = []\n",
+    "context_len = context_latents.shape[1]\n",
+    "for i in range(target_rgb.shape[0]):\n",
+    "    vid = video_stride[context_len + i]\n",
+    "    tgt = (target_rgb[i] * 255).astype(np.uint8)\n",
+    "    pred = (pred_rgb[i] * 255).astype(np.uint8)\n",
+    "    frame = np.concatenate([vid, tgt, pred], axis=1)\n",
+    "    frames.append(frame)\n",
+    "imageio.mimsave(sample_root / 'comparison.gif', frames, fps=4)\n",
+    "sample_root / 'comparison.gif'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Image\n",
+    "Image(filename=str(sample_root / 'comparison.gif'))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Save sample batches with video, context/target latents, and model predictions into `experiments/dumps`
- Dump one sample after each epoch, tagging files with data index and epoch
- Add notebook for PCA visualisation and GIF comparison of real frames, latents, and predictions
- Use dump directory from main configuration and run visualisation in a dedicated trainer step

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b39211f08332be07740e85dd18e7