### PR TITLE
Remove redundant checkpoint directory creation

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -371,12 +371,6 @@ class Trainer:
         """
 
         ckpt_path: Optional[Path] = Path(checkpoint_dir) if checkpoint_dir else None
-        if ckpt_path is not None and (
-            self.accelerator is None or self.accelerator.is_main_process
-        ):
-            ckpt_path.mkdir(parents=True, exist_ok=True)
-        if ckpt_path is not None and self.accelerator is not None:
-            self.accelerator.wait_for_everyone()
 
         if epochs is None:
             epochs = self.epochs


### PR DESCRIPTION
## Summary
- Avoid re-creating checkpoint directories inside `Trainer.fit` because the experiment setup already generates them

## Testing
- `python -m py_compile training/trainer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c5be6abcc48332927b4fb7b97f6dcb