### PR TITLE
Ensure distributed nodes use local HF cache

### DIFF
--- a/models/backbone.py
+++ b/models/backbone.py
@@ -30,6 +30,11 @@ def build_backbone(backbone_cfg: Any) -> Tuple[Any, Any]:
                 dist.barrier()
                 return obj
             dist.barrier()
+            # Ensure non-zero ranks only read from the local cache to
+            # avoid race conditions when multiple processes attempt to
+            # download the same weights simultaneously.
+            kwargs = dict(kwargs)
+            kwargs.setdefault("local_files_only", True)
             return fn(*args, **kwargs)
         return fn(*args, **kwargs)
 


### PR DESCRIPTION
## Summary
- avoid simultaneous remote downloads by defaulting to `local_files_only` on non-zero ranks

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c72eb5639c83328b9ec34717bb180b