### PR TITLE
Add latent dimension inference utility

### DIFF
--- a/configs/backbones/dinov3.yaml
+++ b/configs/backbones/dinov3.yaml
@@ -4,3 +4,4 @@ backbone:
   hf_repo: facebook/dinov3-vitl16-pretrain-lvd1689m
   image_size: 256
   frame_stride: 2
+  patch_size: 16

--- a/configs/backbones/vjepa2.yaml
+++ b/configs/backbones/vjepa2.yaml
@@ -3,3 +3,4 @@ backbone:
   model_name: vjepa2_vitl_fpc64_256
   hf_repo: facebook/vjepa2-vitl-fpc64-256
   image_size: 256
+  patch_size: 16

--- a/utils/latents.py
+++ b/utils/latents.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+
+def infer_latent_dimensions(cfg: DictConfig) -> tuple[int, int, int]:
+    """Infer temporal and spatial latent dimensions from configuration.
+
+    Returns a tuple ``(t, h, w)`` where ``t`` is the number of temporal latents
+    and ``h``/``w`` are the number of spatial tokens along each dimension.
+    """
+    train_cfg = cfg["DATASETS"]["TRAIN"]
+    dataset_cfg = train_cfg[train_cfg["NAME"].upper()]
+    n_frames = dataset_cfg["N_FRAME"]
+    t_stride = dataset_cfg["STRIDE"]
+    temporal = n_frames // t_stride
+
+    backbone_cfg = cfg["BACKBONE"]
+    image_size = backbone_cfg["IMAGE_SIZE"]
+    patch_size = backbone_cfg["PATCH_SIZE"]
+    spatial = image_size // patch_size
+
+    return temporal, spatial, spatial


### PR DESCRIPTION
## Summary
- add patch size to backbone configs
- add helper to compute temporal and spatial latent dimensions from config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7dd99786c8332b2e78d6eba1efc9b