### PR TITLE
Centralize frame count and dynamic cross-attention queries

### DIFF
--- a/configs/datasets/kinetics_400.yaml
+++ b/configs/datasets/kinetics_400.yaml
@@ -2,7 +2,7 @@ datasets:
   train:
     name: kinetics_400
     kinetics_400:
-      n_frame: 64
+      n_frame: ${TRAINER.N_FRAMES}
       stride: 2
       paths:
         csv: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_train_paths.csv
@@ -10,7 +10,7 @@ datasets:
   val:
     name: kinetics_400
     kinetics_400:
-      n_frame: 64
+      n_frame: ${TRAINER.N_FRAMES}
       stride: 2
       paths:
         csv: /checkpoint/abardes/datasets/Kinetics400/annotations/k400_val_paths.csv

--- a/configs/datasets/syntheticbouncingshapes.yaml
+++ b/configs/datasets/syntheticbouncingshapes.yaml
@@ -3,7 +3,7 @@ datasets:
     name: synthetic_bouncing_shapes
     synthetic_bouncing_shapes:
       length: 4
-      n_frame: 64
+      n_frame: ${TRAINER.N_FRAMES}
       stride: 2
       image_size: 256
       square_size: 64

--- a/configs/training/trainer_deterministic.yaml
+++ b/configs/training/trainer_deterministic.yaml
@@ -1,6 +1,7 @@
 wandb: True
 encoder_trainable: false
 trainer:
+  n_frames: 64
   training:
     learning_rate: 1e-5
     weight_decay: 0.01

--- a/configs/training/trainer_deterministic_cross_attention.yaml
+++ b/configs/training/trainer_deterministic_cross_attention.yaml
@@ -1,6 +1,7 @@
 wandb: True
 encoder_trainable: false
 trainer:
+  n_frames: 64
   training:
     learning_rate: 1e-5
     weight_decay: 0.01

--- a/configs/training/trainer_flow_matching.yaml
+++ b/configs/training/trainer_flow_matching.yaml
@@ -1,6 +1,7 @@
 wandb: True
 encoder_trainable: false
 trainer:
+  n_frames: 64
   training:
     learning_rate: 1e-5
     weight_decay: 0.01

--- a/models/models.py
+++ b/models/models.py
@@ -13,6 +13,7 @@ from einops import rearrange
 from .backbone import build_backbone
 
 from .DiT import DiT, PredictorTransformer, PredictorTransformerCrossAttention
+from utils.latents import infer_latent_dimensions
 
 logger = logging.getLogger(__name__)
 
@@ -283,11 +284,11 @@ class DeterministicCrossAttentionLatentVideoModel(LatentVideoBase):
         dit_cfg = {k.lower(): v for k, v in config.MODEL.DIT.items()}
         self.predictor = PredictorTransformerCrossAttention(**dit_cfg)
 
-        # hardcode for now, make dynamic later
-        D = 1024
-        T = int(config.MODEL.NUM_TARGET_LATENTS)
-        H = 16
-        W = 16
+        # Initialise target queries based on latent dimensions
+        _, num_target_latents, spatial = infer_latent_dimensions(config)
+        D = int(config.MODEL.DIT.INPUT_DIM)
+        T = int(num_target_latents)
+        H = W = int(spatial)
         target_queries = nn.Parameter(torch.randn(1, T * H * W, D))
         self.register_parameter("target_queries", target_queries)
 

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -150,7 +150,9 @@ class Trainer:
         # Evaluation parameters
         self.eval_every = int(config.EVALUATION.EVAL_EVERY)
         self.eval_first = bool(config.EVALUATION.EVAL_FIRST)
-        
+        # Global configuration
+        self.n_frames = int(config.N_FRAMES)
+
         # Training parameters
         self.epochs = int(config.TRAINING.EPOCHS) if not self.debug else 1
         self.max_grad_norm = config.TRAINING.MAX_GRAD_NORM

--- a/utils/config.py
+++ b/utils/config.py
@@ -18,7 +18,11 @@ def _merge_with_conflict(base: OmegaConf, override: OmegaConf) -> OmegaConf:
 def _uppercase_keys(cfg: Any) -> Any:
     """Recursively convert all mapping keys to upper case."""
     if isinstance(cfg, DictConfig):
-        data = {k.upper(): _uppercase_keys(v) for k, v in cfg.items()}
+        # ``items_ex(resolve=False)`` preserves unresolved interpolations so that
+        # cross-file references remain intact after merging. Using ``items()``
+        # would attempt to resolve them immediately, which fails when the
+        # referenced keys are defined in a later config.
+        data = {k.upper(): _uppercase_keys(v) for k, v in cfg.items_ex(resolve=False)}
         return OmegaConf.create(data)
     if isinstance(cfg, ListConfig):
         return OmegaConf.create([_uppercase_keys(v) for v in cfg])

--- a/utils/latents.py
+++ b/utils/latents.py
@@ -4,20 +4,23 @@ from omegaconf import DictConfig
 
 
 def infer_latent_dimensions(cfg: DictConfig) -> tuple[int, int, int]:
-    """Infer temporal and spatial latent dimensions from configuration.
+    """Return context/target temporal latents and spatial tokens from config.
 
-    Returns a tuple ``(t, h, w)`` where ``t`` is the number of temporal latents
-    and ``h``/``w`` are the number of spatial tokens along each dimension.
+    The configuration already specifies ``NUM_CONTEXT_LATENTS`` and
+    ``NUM_TARGET_LATENTS`` under ``MODEL``. This helper simply reads those
+    values and computes the spatial token count per dimension using the
+    backbone's image and patch sizes.
+
+    Returns a tuple ``(n_context, n_target, spatial)`` where ``spatial`` is the
+    number of spatial tokens along a single dimension (height/width).
     """
-    train_cfg = cfg["DATASETS"]["TRAIN"]
-    dataset_cfg = train_cfg[train_cfg["NAME"].upper()]
-    n_frames = dataset_cfg["N_FRAME"]
-    t_stride = dataset_cfg["STRIDE"]
-    temporal = n_frames // t_stride
+    model_cfg = cfg["MODEL"]
+    n_context = int(model_cfg["NUM_CONTEXT_LATENTS"])
+    n_target = int(model_cfg["NUM_TARGET_LATENTS"])
 
     backbone_cfg = cfg["BACKBONE"]
-    image_size = backbone_cfg["IMAGE_SIZE"]
-    patch_size = backbone_cfg["PATCH_SIZE"]
+    image_size = int(backbone_cfg["IMAGE_SIZE"])
+    patch_size = int(backbone_cfg["PATCH_SIZE"])
     spatial = image_size // patch_size
 
-    return temporal, spatial, spatial
+    return n_context, n_target, spatial


### PR DESCRIPTION
## Summary
- expose `n_frames` in trainer configs and access it through `Trainer.n_frames`
- reference `n_frame` in dataset configs from the trainer variable
- infer latent dimensions directly from config and use them to size cross-attention queries
- allow unresolved config interpolation when uppercasing keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7e13bbe20833290b5f782cf9d997a