### PR TITLE
Save evaluation latents

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -242,7 +242,7 @@ class FlowMatchingLatentVideoModel(LatentVideoBase):
         timesteps = t * self.num_train_timesteps
 
         prediction = self.flow_transformer(context_latents, xt, timesteps)  # predict velocity
-        return prediction, velocity
+        return prediction, velocity, context_latents, target_latents
 
     def trainable_modules(self) -> Iterable[nn.Module]:  # optional: curated list
         yield from [m for m in [self.encoder, self.flow_transformer] if m is not None]
@@ -266,7 +266,7 @@ class DeterministicLatentVideoModel(LatentVideoBase):
         target_latents  = rearrange(target_latents,  "b d t h w -> b (t h w) d")
 
         prediction = self.predictor(context_latents)  # direct next-token prediction
-        return prediction, target_latents
+        return prediction, target_latents, context_latents, target_latents
 
     def trainable_modules(self) -> Iterable[nn.Module]:  # optional: curated list
         yield from [m for m in [self.encoder, self.predictor] if m is not None]
@@ -306,7 +306,7 @@ class DeterministicCrossAttentionLatentVideoModel(LatentVideoBase):
         target_queries = self.target_queries.repeat(context_latents.shape[0], 1, 1)  # [B, (T*H*W), D]
 
         prediction = self.predictor(context_latents, target_queries)
-        return prediction, target_latents
+        return prediction, target_latents, context_latents, target_latents
 
     def trainable_modules(self) -> Iterable[nn.Module]:  # optional: curated list
         yield from [m for m in [self.encoder, self.predictor] if m is not None]


### PR DESCRIPTION
## Summary
- Capture context and target latents in model forward methods
- Collect and save evaluation latents per video during validation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7e3e99bd0833293941dea04e97588