### PR TITLE
Avoid redundant config resolution and remove print helper

### DIFF
--- a/src/locator/main.py
+++ b/src/locator/main.py
@@ -5,12 +5,13 @@ import torch
 import wandb
 from accelerate import Accelerator
 from accelerate.utils import DistributedDataParallelKwargs
+from omegaconf import OmegaConf
 
 from models import build_model
 from datasets import build_dataset
 from training import build_trainer
 from utils.parser import create_parser
-from utils.config import load_config, print_config
+from utils.config import load_config
 from utils.filesystem import make_experiment_dirs
 
 
@@ -23,6 +24,7 @@ def main() -> None:
 
     config_path = Path(args.config_path)
     config = load_config(config_path)
+    OmegaConf.resolve(config)
     config_name = config_path.stem
     
     # ------------------------------------------------------------------
@@ -140,8 +142,8 @@ def main() -> None:
 
     if accelerator.is_main_process:
         model.count_parameters()
-        resolved_config = print_config(config)
-        logger.info(resolved_config)
+        resolved_config = OmegaConf.to_yaml(config)
+        logger.info("Resolved configuration:\n%s", resolved_config)
         resolved_config_path = dirs.config_dir / "resolved_config.yaml"
         resolved_config_path.write_text(resolved_config)
         if use_wandb:

--- a/src/main.py
+++ b/src/main.py
@@ -3,11 +3,12 @@ import logging
 import shutil
 import torch
 import wandb
+from omegaconf import OmegaConf
 from models import build_model
 from datasets import build_dataset
 from training import build_trainer
 from utils.parser import create_parser
-from utils.config import load_config, print_config
+from utils.config import load_config
 from utils.filesystem import make_experiment_dirs
 from accelerate import Accelerator
 from accelerate.utils import DistributedDataParallelKwargs
@@ -20,10 +21,8 @@ def main() -> None:
 
     config_path = Path(args.config_path)
     config = load_config(config_path)
+    OmegaConf.resolve(config)
     config_name = config_path.stem
-    # resolve here
-    
-    # once resolved, log it
 
     # ------------------------------------------------------------------
     # Accelerator initialisation
@@ -138,8 +137,8 @@ def main() -> None:
 
     if accelerator.is_main_process:
         model.count_parameters()
-        resolved_config = print_config(config)
-        logger.info(resolved_config)
+        resolved_config = OmegaConf.to_yaml(config)
+        logger.info("Resolved configuration:\n%s", resolved_config)
         resolved_config_path = dirs.config_dir / "resolved_config.yaml"
         resolved_config_path.write_text(resolved_config)
         if use_wandb:

--- a/utils/config.py
+++ b/utils/config.py
@@ -53,9 +53,3 @@ def load_config(path: Path) -> DictConfig:
         merged = _merge_with_conflict(merged, sub_cfg)
     merged = _merge_with_conflict(merged, cfg)
     return merged
-
-
-def print_config(config: DictConfig) -> str:
-    """Return the resolved configuration in YAML format (no printing)."""
-    yaml_str = OmegaConf.to_yaml(config)
-    return yaml_str


### PR DESCRIPTION
## Summary
- avoid resolving the configuration twice when logging from `src/main.py`
- remove the unused `print_config` helper and resolve/log configs directly in the locator entry point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9192c74588332bed1a620d552edff