### PR TITLE
Set pin_memory on all dataloaders

### DIFF
--- a/src/locator/main.py
+++ b/src/locator/main.py
@@ -102,12 +102,14 @@ def main() -> None:
         shuffle=True,
         num_workers=num_workers,
         batch_size=train_batch_size,
+        pin_memory=True,
     )
     val_dataloader = torch.utils.data.DataLoader(
         val_dataset,
         shuffle=False,
         num_workers=num_workers,
         batch_size=eval_batch_size,
+        pin_memory=True,
     )
     # Visualisation dataloader: use same num_workers and batch size from config
     visualisation_batch_size = config.TRAINER.EVALUATION.BATCH_SIZE_PER_GPU
@@ -116,6 +118,7 @@ def main() -> None:
         shuffle=False,
         num_workers=num_workers,
         batch_size=visualisation_batch_size,
+        pin_memory=True,
     )
     log_file = dirs.logs_dir / "train.log"
     if accelerator.is_main_process:

--- a/src/main.py
+++ b/src/main.py
@@ -109,12 +109,14 @@ def main() -> None:
         shuffle=True,
         num_workers=num_workers,
         batch_size=train_batch_size,
+        pin_memory=True,
     )
     val_dataloader = torch.utils.data.DataLoader(
         val_dataset,
         shuffle=False,
         num_workers=num_workers,
         batch_size=eval_batch_size,
+        pin_memory=True,
     )
     # Visualisation dataloader: use same num_workers and batch size from config
     visualisation_batch_size = config.TRAINER.EVALUATION.BATCH_SIZE_PER_GPU
@@ -123,6 +125,7 @@ def main() -> None:
         shuffle=False,
         num_workers=num_workers,
         batch_size=visualisation_batch_size,
+        pin_memory=True,
     )
 
     logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- enable pinned memory for accelerator training dataloaders in src/main.py
- enable pinned memory for accelerator training dataloaders in src/locator/main.py

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c935dae03083329716da08ef3462cb