### PR TITLE
Fix batch device transfer for locator evaluation

### DIFF
--- a/training/trainer.py
+++ b/training/trainer.py
@@ -30,6 +30,7 @@ from utils.video import (
 from utils.pca import pca_latents_to_video_tensors
 from .losses import get_criterion
 from utils.latents import infer_latent_dimensions
+from utils.torch_utils import _move_batch_to_device
 
 @dataclass
 class TrainState:
@@ -539,6 +540,7 @@ class Trainer:
         )
 
         for batch_idx, batch in enumerate(progress_bar):
+            batch = _move_batch_to_device(batch)
             batch_loss, _, _, _ = self.run_evaluation_step(batch)
             total_loss_local += batch_loss
             num_batches_local += 1
@@ -712,7 +714,7 @@ class LocatorTrainer(Trainer):
             debug=debug,
             dump_dir=dump_dir,
         )
-        
+
     # ------------------------------------------------------------------
     # Visualisation utilities
     # ------------------------------------------------------------------

--- a/utils/torch_utils.py
+++ b/utils/torch_utils.py
@@ -1,0 +1,41 @@
+"""Utility helpers for working with PyTorch tensors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from accelerate.state import AcceleratorState
+import torch
+
+
+def _move_batch_to_device(batch: Any) -> Any:
+    """Recursively move tensors in ``batch`` to the current accelerator device."""
+
+    device = AcceleratorState().device
+    return _move_batch_with_device(batch, device)
+
+
+def _move_batch_with_device(obj: Any, device: torch.device) -> Any:
+    if isinstance(obj, Mapping):
+        return {key: _move_batch_with_device(value, device) for key, value in obj.items()}
+
+    if isinstance(obj, tuple):
+        return tuple(_move_batch_with_device(value, device) for value in obj)
+
+    if isinstance(obj, list):
+        return [_move_batch_with_device(value, device) for value in obj]
+
+    if isinstance(obj, set):
+        return {_move_batch_with_device(value, device) for value in obj}
+
+    return _move_to_device(obj, device)
+
+
+def _move_to_device(obj: Any, device: torch.device) -> Any:
+    if isinstance(obj, torch.Tensor):
+        return obj.to(device=device, non_blocking=True)
+    return obj
+
+
+__all__ = ["_move_batch_to_device"]


### PR DESCRIPTION
## Summary
- update `_move_batch_to_device` to use the accelerator state device and simplify the tensor move helper
- move validation batches onto the accelerator inside `Trainer.run_evaluation`
- rely on the shared evaluation flow for `LocatorTrainer` instead of duplicating it

## Testing
- python -m compileall utils/torch_utils.py training/trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68c93803139083328fa6de0535521fb4